### PR TITLE
feat : 북마크와 레시피북 변경 로직 추가 & 외부레시피 파싱 정리 (#37)

### DIFF
--- a/src/main/java/com/shortkki/api/recipe/dto/request/RecipeCreateRequest.java
+++ b/src/main/java/com/shortkki/api/recipe/dto/request/RecipeCreateRequest.java
@@ -26,7 +26,9 @@ public record RecipeCreateRequest(
         List<StepRequest> steps,
 
         @NotNull(message = "출처 타입은 필수입니다.")
-        RecipeSource recipeSource
+        RecipeSource recipeSource,
+
+        List<String> tags
 ) {
 
 }

--- a/src/main/java/com/shortkki/api/recipe/dto/request/RecipeUpdateRequest.java
+++ b/src/main/java/com/shortkki/api/recipe/dto/request/RecipeUpdateRequest.java
@@ -19,7 +19,9 @@ public record RecipeUpdateRequest(
 
         @Valid @NotNull(message = "조리 순서는 필수입니다.")
         @Size(min = 1, message = "조리 순서는 최소 1개 이상이어야 합니다.")
-        List<StepRequest> steps
+        List<StepRequest> steps,
+
+        List<String> tags
 ) {
 
 }

--- a/src/main/java/com/shortkki/api/recipe/dto/response/RecipeResponse.java
+++ b/src/main/java/com/shortkki/api/recipe/dto/response/RecipeResponse.java
@@ -29,11 +29,14 @@ public record RecipeResponse(
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
         List<StepResponse> steps,
-        List<IngredientResponse> ingredients
+        List<IngredientResponse> ingredients,
+        List<String> tags
 ) {
 
     public static RecipeResponse toDto(Recipe recipe, List<RecipeStep> steps,
-            List<RecipeIngredient> ingredients) {
+            List<RecipeIngredient> ingredients,
+            List<String> tags
+    ) {
 
         List<StepResponse> stepResponses = steps.stream()
                 .map(s -> new StepResponse(s.getStepOrder(), s.getDescription()))
@@ -63,6 +66,8 @@ public record RecipeResponse(
                 recipe.getCreatedAt(),
                 recipe.getUpdatedAt(),
                 stepResponses,
-                ingredientResponses);
+                ingredientResponses,
+                tags != null ? tags : List.of()
+        );
     }
 }

--- a/src/main/java/com/shortkki/api/recipe/entity/Recipe.java
+++ b/src/main/java/com/shortkki/api/recipe/entity/Recipe.java
@@ -22,6 +22,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -30,6 +31,8 @@ import org.hibernate.annotations.ColumnDefault;
 @Entity
 @Table(name = "recipe")
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Recipe extends BaseEntity {
 

--- a/src/main/java/com/shortkki/api/recipe/entity/Recipe.java
+++ b/src/main/java/com/shortkki/api/recipe/entity/Recipe.java
@@ -56,7 +56,7 @@ public class Recipe extends BaseEntity {
 
     @Column(nullable = false)
     @ColumnDefault("0")
-    private Integer bookmarkCount = 0;
+    private Integer bookmarkCount;
 
     @Enumerated(EnumType.STRING)
     @Column(length = 50)
@@ -66,7 +66,8 @@ public class Recipe extends BaseEntity {
     private Long imageFileId;
 
     @Column(nullable = false)
-    private Boolean isDeleted = false;
+    @ColumnDefault("0")
+    private Boolean isDeleted;
 
     @Builder
     private Recipe(

--- a/src/main/java/com/shortkki/api/recipe/entity/Recipe.java
+++ b/src/main/java/com/shortkki/api/recipe/entity/Recipe.java
@@ -55,8 +55,8 @@ public class Recipe extends BaseEntity {
     private RecipeCategoryInfo categoryInfo;
 
     @Column(nullable = false)
-    @ColumnDefault("0")
-    private Integer bookmarkCount;
+    @Builder.Default
+    private Integer bookmarkCount = 0;
 
     @Enumerated(EnumType.STRING)
     @Column(length = 50)
@@ -66,8 +66,8 @@ public class Recipe extends BaseEntity {
     private Long imageFileId;
 
     @Column(nullable = false)
-    @ColumnDefault("0")
-    private Boolean isDeleted;
+    @Builder.Default
+    private Boolean isDeleted = false;
 
     @Builder
     private Recipe(

--- a/src/main/java/com/shortkki/api/recipe/entity/Recipe.java
+++ b/src/main/java/com/shortkki/api/recipe/entity/Recipe.java
@@ -51,6 +51,7 @@ public class Recipe extends BaseEntity {
     @Embedded
     private RecipeCategoryInfo categoryInfo;
 
+    @Column(nullable = false)
     @ColumnDefault("0")
     private Integer bookmarkCount = 0;
 
@@ -134,5 +135,15 @@ public class Recipe extends BaseEntity {
 
     public void setImageFileId(Long imageFileId) {
         this.imageFileId = imageFileId;
+    }
+
+    public void incrementBookmarkCount() {
+        this.bookmarkCount++;
+    }
+
+    public void decrementBookmarkCount() {
+        if (this.bookmarkCount > 0) {
+            this.bookmarkCount--;
+        }
     }
 }

--- a/src/main/java/com/shortkki/api/recipe/entity/RecipeTag.java
+++ b/src/main/java/com/shortkki/api/recipe/entity/RecipeTag.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,7 +14,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "recipe_tag")
+@Table(name = "recipe_tag",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"recipe_id", "tag_id"})
+        })
 @Getter
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/src/main/java/com/shortkki/api/recipe/repository/RecipeTagRepository.java
+++ b/src/main/java/com/shortkki/api/recipe/repository/RecipeTagRepository.java
@@ -3,10 +3,20 @@ package com.shortkki.api.recipe.repository;
 import com.shortkki.api.recipe.entity.RecipeTag;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface RecipeTagRepository extends JpaRepository<RecipeTag, Long> {
 
     List<RecipeTag> findByRecipeId(Long recipeId);
 
     void deleteByRecipeId(Long recipeId);
+
+    @Query("""
+                select t.name
+                from RecipeTag rt
+                join Tag t on t.id = rt.tagId
+                where rt.recipeId = :recipeId
+            """)
+    List<String> findTagNamesByRecipeId(@Param("recipeId") Long recipeId);
 }

--- a/src/main/java/com/shortkki/api/recipe/repository/RecipeTagRepository.java
+++ b/src/main/java/com/shortkki/api/recipe/repository/RecipeTagRepository.java
@@ -1,0 +1,12 @@
+package com.shortkki.api.recipe.repository;
+
+import com.shortkki.api.recipe.entity.RecipeTag;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecipeTagRepository extends JpaRepository<RecipeTag, Long> {
+
+    List<RecipeTag> findByRecipeId(Long recipeId);
+
+    void deleteByRecipeId(Long recipeId);
+}

--- a/src/main/java/com/shortkki/api/recipe/repository/TagRepository.java
+++ b/src/main/java/com/shortkki/api/recipe/repository/TagRepository.java
@@ -1,0 +1,15 @@
+package com.shortkki.api.recipe.repository;
+
+import com.shortkki.api.recipe.entity.Tag;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+    Optional<Tag> findByName(String name);
+
+    List<Tag> findAllByNameIn(Collection<String> names);
+}

--- a/src/main/java/com/shortkki/api/recipe/service/RecipeQueryService.java
+++ b/src/main/java/com/shortkki/api/recipe/service/RecipeQueryService.java
@@ -4,9 +4,13 @@ import com.shortkki.api.recipe.dto.response.RecipeResponse;
 import com.shortkki.api.recipe.entity.Recipe;
 import com.shortkki.api.recipe.entity.RecipeIngredient;
 import com.shortkki.api.recipe.entity.RecipeStep;
+import com.shortkki.api.recipe.entity.RecipeTag;
+import com.shortkki.api.recipe.entity.Tag;
 import com.shortkki.api.recipe.repository.RecipeIngredientRepository;
 import com.shortkki.api.recipe.repository.RecipeRepository;
 import com.shortkki.api.recipe.repository.RecipeStepRepository;
+import com.shortkki.api.recipe.repository.RecipeTagRepository;
+import com.shortkki.api.recipe.repository.TagRepository;
 import com.shortkki.global.error.ErrorCode;
 import com.shortkki.global.error.exception.BusinessException;
 import java.util.List;
@@ -23,6 +27,9 @@ public class RecipeQueryService {
     private final RecipeStepRepository recipeStepRepository;
     private final RecipeIngredientRepository recipeIngredientRepository;
 
+    private final RecipeTagRepository recipeTagRepository;
+    private final TagRepository tagRepository;
+
     public Recipe findRecipe(Long id) {
         return recipeRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.RECIPE_NOT_FOUND));
@@ -37,7 +44,8 @@ public class RecipeQueryService {
         List<RecipeIngredient> ingredients = recipeIngredientRepository.findByRecipeId(
                 recipe.getId());
 
-        return RecipeResponse.toDto(recipe, steps, ingredients);
+        List<String> tagNames = findTagNamesByRecipeId(recipe.getId());
+        return RecipeResponse.toDto(recipe, steps, ingredients, tagNames);
     }
 
     // TODO: N+1 문제 해결 (Fetch Join 고려)
@@ -51,8 +59,13 @@ public class RecipeQueryService {
                     List<RecipeStep> steps = recipeStepRepository.findByRecipeId(recipe.getId());
                     List<RecipeIngredient> ingredients = recipeIngredientRepository.findByRecipeId(
                             recipe.getId());
-                    return RecipeResponse.toDto(recipe, steps, ingredients);
+                    List<String> tagNames = findTagNamesByRecipeId(recipe.getId());
+                    return RecipeResponse.toDto(recipe, steps, ingredients, tagNames);
                 })
                 .toList();
+    }
+
+    private List<String> findTagNamesByRecipeId(Long recipeId) {
+        return recipeTagRepository.findTagNamesByRecipeId(recipeId);
     }
 }

--- a/src/main/java/com/shortkki/api/recipe/service/RecipeService.java
+++ b/src/main/java/com/shortkki/api/recipe/service/RecipeService.java
@@ -4,6 +4,7 @@ import com.shortkki.api.file.entity.FileMetadata;
 import com.shortkki.api.file.entity.FileTargetType;
 import com.shortkki.api.file.service.FileMetadataService;
 import com.shortkki.api.recipe.entity.RecipeSource;
+import com.shortkki.api.recipe.entity.TagSource;
 import com.shortkki.api.recipe.dto.request.BasicInfoRequest;
 import com.shortkki.api.recipe.dto.request.CategoryInfoRequest;
 import com.shortkki.api.recipe.dto.request.RecipeCreateRequest;
@@ -12,6 +13,7 @@ import com.shortkki.api.recipe.entity.Recipe;
 import com.shortkki.api.recipe.entity.vo.RecipeBasicInfo;
 import com.shortkki.api.recipe.entity.vo.RecipeCategoryInfo;
 import com.shortkki.api.recipe.repository.RecipeRepository;
+import com.shortkki.api.recipe.repository.RecipeTagRepository;
 import com.shortkki.api.recipeBook.entity.RecipeBook;
 import com.shortkki.api.recipeBook.service.RecipeBookQueryService;
 import com.shortkki.api.recipeBook.service.RecipeBookService;
@@ -38,6 +40,8 @@ public class RecipeService {
     private final RecipeBookService recipeBookService;
     private final RecipeBookQueryService recipeBookQueryService;
     private final FileMetadataService fileMetadataService;
+    private final TagService tagService;
+    private final RecipeTagRepository recipeTagRepository;
 
     public void create(Long memberId, RecipeCreateRequest request) {
         validateRecipeRequest(request);
@@ -62,6 +66,7 @@ public class RecipeService {
 
         recipeStepService.createSteps(saved, request.steps());
         recipeIngredientService.createIngredients(saved, request.ingredients());
+        tagService.saveRecipeTags(saved.getId(), request.tags(), TagSource.USER);
 
         addToDefaultRecipeBook(memberId, saved.getId());
     }
@@ -95,15 +100,18 @@ public class RecipeService {
 
         recipeStepService.deleteByRecipeId(id);
         recipeIngredientService.deleteByRecipeId(id);
+        recipeTagRepository.deleteByRecipeId(id);
 
         recipeStepService.createSteps(recipe, request.steps());
         recipeIngredientService.createIngredients(recipe, request.ingredients());
+        tagService.saveRecipeTags(recipe.getId(), request.tags(), TagSource.USER);
     }
 
     public void delete(Long id) {
         recipeRepository.findById(id).ifPresent(recipe -> {
             recipeStepService.deleteByRecipeId(id);
             recipeIngredientService.deleteByRecipeId(id);
+            recipeTagRepository.deleteByRecipeId(id);
             recipeRepository.delete(recipe);
         });
     }
@@ -120,8 +128,6 @@ public class RecipeService {
             file.bindTarget(FileTargetType.RECIPE_IMG, saved.getId());
             saved.setImageFileId(imageFileId);
         }
-
-        // TODO: 태그 저장 로직 추가
 
         return saved;
     }

--- a/src/main/java/com/shortkki/api/recipe/service/TagService.java
+++ b/src/main/java/com/shortkki/api/recipe/service/TagService.java
@@ -1,0 +1,70 @@
+package com.shortkki.api.recipe.service;
+
+import com.shortkki.api.recipe.entity.RecipeTag;
+import com.shortkki.api.recipe.entity.Tag;
+import com.shortkki.api.recipe.entity.TagSource;
+import com.shortkki.api.recipe.repository.RecipeTagRepository;
+import com.shortkki.api.recipe.repository.TagRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TagService {
+
+    private final TagRepository tagRepository;
+    private final RecipeTagRepository recipeTagRepository;
+
+    /**
+     * 기존 tag가 있으면 재사용 (sourceType 변경 안 함).
+     * 없으면 주어진 source로 신규 생성.
+     * DataIntegrityViolationException은 동시성 경합 대비.
+     */
+    public Tag getOrCreateTag(String name, TagSource source) {
+        try {
+            return tagRepository.findByName(name)
+                    .orElseGet(() -> {
+                        Tag newTag = (source == TagSource.SYSTEM)
+                                ? Tag.createSystemTag(name)
+                                : Tag.createUserTag(name);
+                        return tagRepository.save(newTag);
+                    });
+        } catch (DataIntegrityViolationException e) {
+            return tagRepository.findByName(name).orElseThrow(() -> e);
+        }
+    }
+
+    /**
+     * recipeId에 대한 tag 목록을 저장.
+     * null/blank 제거, trim, 중복 제거 후 저장.
+     * Tag 엔티티 자체는 shared이므로 삭제하지 않음.
+     */
+    public void saveRecipeTags(Long recipeId, List<String> tagNames, TagSource source) {
+        List<String> normalized = normalize(tagNames);
+        if (normalized.isEmpty()) {
+            return;
+        }
+
+        List<RecipeTag> recipeTags = new ArrayList<>(normalized.size());
+        for (String name : normalized) {
+            Tag tag = getOrCreateTag(name, source);
+            recipeTags.add(RecipeTag.of(recipeId, tag.getId()));
+        }
+
+        recipeTagRepository.saveAll(recipeTags);
+    }
+
+    private List<String> normalize(List<String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return List.of();
+        }
+        return tags.stream()
+                .filter(t -> t != null && !t.isBlank())
+                .map(String::trim)
+                .distinct()
+                .toList();
+    }
+}

--- a/src/main/java/com/shortkki/api/recipe/service/TagService.java
+++ b/src/main/java/com/shortkki/api/recipe/service/TagService.java
@@ -19,9 +19,8 @@ public class TagService {
     private final RecipeTagRepository recipeTagRepository;
 
     /**
-     * 기존 tag가 있으면 재사용 (sourceType 변경 안 함).
-     * 없으면 주어진 source로 신규 생성.
-     * DataIntegrityViolationException은 동시성 경합 대비.
+     * 기존 tag가 있으면 재사용 (sourceType 변경 안 함). 없으면 주어진 source로 신규 생성. DataIntegrityViolationException은
+     * 동시성 경합 대비.
      */
     public Tag getOrCreateTag(String name, TagSource source) {
         try {
@@ -36,12 +35,7 @@ public class TagService {
             return tagRepository.findByName(name).orElseThrow(() -> e);
         }
     }
-
-    /**
-     * recipeId에 대한 tag 목록을 저장.
-     * null/blank 제거, trim, 중복 제거 후 저장.
-     * Tag 엔티티 자체는 shared이므로 삭제하지 않음.
-     */
+    
     public void saveRecipeTags(Long recipeId, List<String> tagNames, TagSource source) {
         List<String> normalized = normalize(tagNames);
         if (normalized.isEmpty()) {

--- a/src/main/java/com/shortkki/api/recipeBook/controller/RecipeBookController.java
+++ b/src/main/java/com/shortkki/api/recipeBook/controller/RecipeBookController.java
@@ -5,6 +5,7 @@ import com.shortkki.api.recipeBook.dto.RecipeBookCreateRequest;
 import com.shortkki.api.recipeBook.dto.RecipeBookReorderRequest;
 import com.shortkki.api.recipeBook.dto.RecipeBookResponse;
 import com.shortkki.api.recipeBook.dto.RecipeBookUpdateRequest;
+import com.shortkki.api.recipeBook.dto.RecipeMoveRequest;
 import com.shortkki.api.recipeBook.service.RecipeBookService;
 import com.shortkki.global.auth.dto.LoginMember;
 import com.shortkki.global.response.BaseResponse;
@@ -115,4 +116,21 @@ public class RecipeBookController {
         recipeBookService.removeRecipe(loginMember.getId(), id, recipeId);
         return ResponseEntity.ok(BaseResponse.success());
     }
+
+    @PatchMapping("/{fromBookId}/recipes/{recipeId}")
+    public ResponseEntity<BaseResponse<Void>> moveRecipe(
+            @AuthenticationPrincipal LoginMember loginMember,
+            @PathVariable Long fromBookId,
+            @PathVariable Long recipeId,
+            @Valid @RequestBody RecipeMoveRequest request
+    ) {
+        recipeBookService.moveRecipe(
+                loginMember.getId(),
+                fromBookId,
+                request.toRecipeBookId(),
+                recipeId
+        );
+        return ResponseEntity.ok(BaseResponse.success());
+    }
+
 }

--- a/src/main/java/com/shortkki/api/recipeBook/dto/RecipeMoveRequest.java
+++ b/src/main/java/com/shortkki/api/recipeBook/dto/RecipeMoveRequest.java
@@ -1,0 +1,9 @@
+package com.shortkki.api.recipeBook.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record RecipeMoveRequest(
+        @NotNull Long toRecipeBookId
+) {
+
+}

--- a/src/main/java/com/shortkki/api/recipeBook/entity/RecipeBookItem.java
+++ b/src/main/java/com/shortkki/api/recipeBook/entity/RecipeBookItem.java
@@ -11,14 +11,20 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Fetch;
 
+
 @Entity
-@Table(name = "recipe_book_item")
+// TODO : 나중에 DB 유니크 제약조건으로 변경 (데이터 정합성을 위해서)
+@Table(name = "recipe_book_item",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"recipe_book_id", "recipe_id"})
+        })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RecipeBookItem extends BaseEntity {

--- a/src/main/java/com/shortkki/api/recipeBook/entity/RecipeBookItem.java
+++ b/src/main/java/com/shortkki/api/recipeBook/entity/RecipeBookItem.java
@@ -20,10 +20,9 @@ import org.hibernate.annotations.Fetch;
 
 
 @Entity
-// TODO : 나중에 DB 유니크 제약조건으로 변경 (데이터 정합성을 위해서)
 @Table(name = "recipe_book_item",
         uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"recipe_book_id", "recipe_id"})
+                @UniqueConstraint(columnNames = {"book_id", "recipe_id"})
         })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/shortkki/api/recipeBook/repository/RecipeBookItemRepository.java
+++ b/src/main/java/com/shortkki/api/recipeBook/repository/RecipeBookItemRepository.java
@@ -23,4 +23,15 @@ public interface RecipeBookItemRepository extends JpaRepository<RecipeBookItem, 
             where i.recipeBook.id = :recipeBookId
             """)
     List<RecipeBookItem> findAllByRecipeBookIdWithRecipe(@Param("recipeBookId") Long recipeBookId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+                update RecipeBookItem rbi
+                   set rbi.recipeBook.id = :toBookId
+                 where rbi.recipeBook.id = :fromBookId
+                   and rbi.recipe.id = :recipeId
+            """)
+    long moveRecipe(@Param("fromBookId") Long fromBookId,
+            @Param("toBookId") Long toBookId,
+            @Param("recipeId") Long recipeId);
 }

--- a/src/main/java/com/shortkki/api/recipeBook/repository/RecipeBookItemRepository.java
+++ b/src/main/java/com/shortkki/api/recipeBook/repository/RecipeBookItemRepository.java
@@ -13,7 +13,14 @@ public interface RecipeBookItemRepository extends JpaRepository<RecipeBookItem, 
 
     boolean existsByRecipeBookIdAndRecipeId(Long recipeBookId, Long recipeId);
 
-    void deleteByRecipeBookIdAndRecipeId(Long recipeBookId, Long recipeId);
+    long deleteByRecipeBookIdAndRecipeId(Long recipeBookId, Long recipeId);
 
-    void deleteAllByRecipeBookId(Long recipeBookId);
+    long deleteAllByRecipeBookId(Long recipeBookId);
+
+    @Query("""
+            select i from RecipeBookItem i
+            join fetch i.recipe 
+            where i.recipeBook.id = :recipeBookId
+            """)
+    List<RecipeBookItem> findAllByRecipeBookIdWithRecipe(@Param("recipeBookId") Long recipeBookId);
 }

--- a/src/main/java/com/shortkki/api/recipeBook/service/RecipeBookService.java
+++ b/src/main/java/com/shortkki/api/recipeBook/service/RecipeBookService.java
@@ -140,10 +140,10 @@ public class RecipeBookService {
 
         recipeBookItemRepository.deleteByRecipeBookIdAndRecipeId(recipeBookId, recipeId);
 
-        Recipe recipe = recipeBookValidationService.findRecipeById(recipeId);
         long deleted = recipeBookItemRepository.deleteByRecipeBookIdAndRecipeId(recipeBookId,
                 recipeId);
         if (deleted > 0) {
+            Recipe recipe = recipeBookValidationService.findRecipeById(recipeId);
             recipe.decrementBookmarkCount();
         }
     }

--- a/src/main/java/com/shortkki/api/recipeBook/service/RecipeBookService.java
+++ b/src/main/java/com/shortkki/api/recipeBook/service/RecipeBookService.java
@@ -14,6 +14,8 @@ import com.shortkki.api.recipeBook.repository.RecipeBookRepository;
 
 import com.shortkki.api.member.entity.Member;
 import com.shortkki.api.group.entity.Group;
+import com.shortkki.global.error.ErrorCode;
+import com.shortkki.global.error.exception.NotFoundException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -196,4 +198,29 @@ public class RecipeBookService {
 
         recipeBookRepository.saveAll(recipeBookMap.values());
     }
+
+    @Transactional
+    public void moveRecipe(Long memberId, Long fromBookId, Long toBookId, Long recipeId) {
+        if (fromBookId.equals(toBookId)) {
+            return;
+        }
+        
+        RecipeBook fromBook = recipeBookValidationService.findRecipeBookById(fromBookId);
+        RecipeBook toBook = recipeBookValidationService.findRecipeBookById(toBookId);
+
+        recipeBookValidationService.validateRecipeBookAccess(fromBook, memberId);
+        recipeBookValidationService.validateRecipeBookAccess(toBook, memberId);
+
+        recipeBookValidationService.validateRecipeNotInBook(toBookId, recipeId);
+
+        recipeBookValidationService.validateRecipeInBook(fromBookId, recipeId);
+
+        long updated = recipeBookItemRepository.moveRecipe(fromBookId, toBookId, recipeId);
+
+        if (updated == 0) {
+            throw new NotFoundException(ErrorCode.RECIPE_NOT_IN_BOOK);
+        }
+    }
+
+
 }

--- a/src/main/java/com/shortkki/api/recipeBook/service/RecipeBookService.java
+++ b/src/main/java/com/shortkki/api/recipeBook/service/RecipeBookService.java
@@ -69,7 +69,7 @@ public class RecipeBookService {
         RecipeBook recipeBook = recipeBookValidationService.findRecipeBookById(id);
         recipeBookValidationService.validateRecipeBookAccess(recipeBook, memberId);
 
-        List<RecipeBookItem> items = recipeBookItemRepository.findAllByRecipeBookId(id);
+        List<RecipeBookItem> items = recipeBookItemRepository.findAllByRecipeBookIdWithRecipe(id);
         List<RecipeSummaryResponse> recipes = items.stream()
                 .map(item -> RecipeSummaryResponse.from(item.getRecipe()))
                 .toList();
@@ -93,6 +93,11 @@ public class RecipeBookService {
         recipeBookValidationService.validateRecipeBookOwnership(recipeBook, memberId);
         recipeBookValidationService.validateNotDefaultRecipeBook(recipeBook);
 
+        List<RecipeBookItem> items = recipeBookItemRepository.findAllByRecipeBookIdWithRecipe(id);
+        for (RecipeBookItem item : items) {
+            item.getRecipe().decrementBookmarkCount();
+        }
+
         recipeBookItemRepository.deleteAllByRecipeBookId(id);
         recipeBookRepository.delete(recipeBook);
     }
@@ -107,6 +112,8 @@ public class RecipeBookService {
 
         RecipeBookItem item = RecipeBookItem.create(recipeBook, recipe);
         recipeBookItemRepository.save(item);
+
+        recipe.incrementBookmarkCount();
     }
 
     @Transactional
@@ -121,6 +128,8 @@ public class RecipeBookService {
 
         RecipeBookItem item = RecipeBookItem.create(recipeBook, recipe);
         recipeBookItemRepository.save(item);
+
+        recipe.incrementBookmarkCount();
     }
 
     @Transactional
@@ -130,6 +139,13 @@ public class RecipeBookService {
         recipeBookValidationService.validateRecipeInBook(recipeBookId, recipeId);
 
         recipeBookItemRepository.deleteByRecipeBookIdAndRecipeId(recipeBookId, recipeId);
+
+        Recipe recipe = recipeBookValidationService.findRecipeById(recipeId);
+        long deleted = recipeBookItemRepository.deleteByRecipeBookIdAndRecipeId(recipeBookId,
+                recipeId);
+        if (deleted > 0) {
+            recipe.decrementBookmarkCount();
+        }
     }
 
     @Transactional

--- a/src/main/java/com/shortkki/api/recipeImport/adapter/GeminiRecipeParserAdapter.java
+++ b/src/main/java/com/shortkki/api/recipeImport/adapter/GeminiRecipeParserAdapter.java
@@ -7,6 +7,9 @@ import com.google.genai.types.GenerateContentConfig;
 import com.google.genai.types.GenerateContentResponse;
 import com.google.genai.types.FileData;
 import com.google.genai.types.Part;
+import com.shortkki.api.recipe.entity.CuisineType;
+import com.shortkki.api.recipe.entity.Difficulty;
+import com.shortkki.api.recipe.entity.MealType;
 import com.shortkki.api.recipeImport.dto.RecipeParseResult;
 import com.shortkki.api.recipeImport.dto.RecipeParseResult.IngredientParseResult;
 import com.shortkki.api.recipeImport.dto.RecipeParseResult.StepParseResult;
@@ -30,7 +33,8 @@ public class GeminiRecipeParserAdapter implements RecipeParserPort {
     static {
         try {
             ClassPathResource resource = new ClassPathResource("prompts/recipe-parser-prompt.txt");
-            PROMPT_TEMPLATE = new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            PROMPT_TEMPLATE = new String(resource.getInputStream().readAllBytes(),
+                    StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new IllegalStateException("Failed to load recipe parser prompt template", e);
         }
@@ -43,7 +47,8 @@ public class GeminiRecipeParserAdapter implements RecipeParserPort {
     public GeminiRecipeParserAdapter(
             @Value("${GOOGLE_GENAI_API_KEY}") String apiKey,
             @Value("${gemini.model-name}") String modelName,
-            ObjectMapper objectMapper) {
+            ObjectMapper objectMapper
+    ) {
         this.modelName = modelName;
         this.client = Client.builder()
                 .apiKey(apiKey)
@@ -70,6 +75,9 @@ public class GeminiRecipeParserAdapter implements RecipeParserPort {
                             .build());
 
             String jsonResult = response.text();
+            if (jsonResult == null || jsonResult.isBlank()) {
+                return RecipeParseResult.empty("파싱 실패");
+            }
             String cleanedJson = stripMarkdown(jsonResult);
             return parseJsonResult(cleanedJson, jsonResult);
 
@@ -80,8 +88,9 @@ public class GeminiRecipeParserAdapter implements RecipeParserPort {
     }
 
     private String stripMarkdown(String content) {
-        if (content == null)
+        if (content == null) {
             return "";
+        }
         String stripped = content.trim();
         if (stripped.startsWith("```json")) {
             stripped = stripped.substring(7);
@@ -97,24 +106,42 @@ public class GeminiRecipeParserAdapter implements RecipeParserPort {
     private RecipeParseResult parseJsonResult(String jsonResult, String rawResponse) {
         try {
             // RecipeParseResult를 직접 파싱 (rawResponse 제외)
-            RecipeParseResultDto dto = objectMapper.readValue(jsonResult, RecipeParseResultDto.class);
+            RecipeParseResultDto dto = objectMapper.readValue(jsonResult,
+                    RecipeParseResultDto.class);
+
+            CuisineType cuisineType = parseEnum(dto.cuisineType(), CuisineType.ETC,
+                    CuisineType.class);
+            MealType mealType = parseEnum(dto.mealType(), MealType.ETC, MealType.class);
+            Difficulty difficulty = parseEnum(dto.difficulty(), Difficulty.ETC, Difficulty.class);
 
             // rawResponse를 포함한 최종 RecipeParseResult 생성
             return new RecipeParseResult(
                     dto.title() != null ? dto.title() : "제목 없음",
                     dto.description(),
                     dto.servingSize() != null ? dto.servingSize() : 1,
-                    dto.cookingTime() != null ? dto.cookingTime() : 30,
-                    dto.cuisineType(),
-                    dto.mealType(),
-                    dto.difficulty(),
+                    dto.cookingTime() != null ? dto.cookingTime() : 10,
+                    cuisineType,
+                    mealType,
+                    difficulty,
                     dto.ingredients() != null ? dto.ingredients() : List.of(),
                     dto.steps() != null ? dto.steps() : List.of(),
+                    dto.tags() != null ? dto.tags() : List.of(),
                     rawResponse);
 
         } catch (Exception e) {
             log.error("JSON 파싱 실패", e);
             return RecipeParseResult.empty("파싱 실패");
+        }
+    }
+
+    private <E extends Enum<E>> E parseEnum(String value, E fallback, Class<E> enumType) {
+        if (value == null || value.isBlank()) {
+            return fallback;
+        }
+        try {
+            return Enum.valueOf(enumType, value.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return fallback;
         }
     }
 
@@ -128,6 +155,9 @@ public class GeminiRecipeParserAdapter implements RecipeParserPort {
             String mealType,
             String difficulty,
             List<IngredientParseResult> ingredients,
-            List<StepParseResult> steps
-    ) {}
+            List<StepParseResult> steps,
+            List<String> tags
+    ) {
+
+    }
 }

--- a/src/main/java/com/shortkki/api/recipeImport/dto/RecipeEditRequest.java
+++ b/src/main/java/com/shortkki/api/recipeImport/dto/RecipeEditRequest.java
@@ -28,6 +28,8 @@ public record RecipeEditRequest(
         String mealType,
         String difficulty,
 
+        List<String> tags,
+
         @NotEmpty(message = "재료는 최소 1개 이상이어야 합니다")
         @Valid
         List<IngredientEditDto> ingredients,
@@ -42,12 +44,15 @@ public record RecipeEditRequest(
             @Size(max = 100, message = "재료명은 100자를 초과할 수 없습니다")
             String name,
 
-            String amount,
+            @NotNull(message = "수량은 필수입니다")
+            @Min(value = 0, message = "수량은 0 이상이어야 합니다(소수점 가능)")
+            Double amount,
 
             @NotBlank(message = "단위는 필수입니다")
             @Size(max = 50, message = "단위는 50자를 초과할 수 없습니다")
             String unit
     ) {
+
     }
 
     public record StepEditDto(
@@ -59,5 +64,6 @@ public record RecipeEditRequest(
             @Size(max = 1000, message = "조리 설명은 1000자를 초과할 수 없습니다")
             String description
     ) {
+
     }
 }

--- a/src/main/java/com/shortkki/api/recipeImport/dto/RecipeParseResult.java
+++ b/src/main/java/com/shortkki/api/recipeImport/dto/RecipeParseResult.java
@@ -1,5 +1,8 @@
 package com.shortkki.api.recipeImport.dto;
 
+import com.shortkki.api.recipe.entity.CuisineType;
+import com.shortkki.api.recipe.entity.Difficulty;
+import com.shortkki.api.recipe.entity.MealType;
 import java.util.List;
 
 public record RecipeParseResult(
@@ -7,21 +10,33 @@ public record RecipeParseResult(
         String description,
         Integer servingSize,
         Integer cookingTime,
-        String cuisineType,
-        String mealType,
-        String difficulty,
+        CuisineType cuisineType,
+        MealType mealType,
+        Difficulty difficulty,
         List<IngredientParseResult> ingredients,
         List<StepParseResult> steps,
+        List<String> tags,
         String rawResponse
 ) {
 
     public static RecipeParseResult empty(String title) {
-        return new RecipeParseResult(title, null, 1, 30, null, null, null, List.of(), List.of(), null);
+        return new RecipeParseResult(
+                title,
+                "",
+                1,
+                0,
+                CuisineType.ETC,
+                MealType.ETC,
+                Difficulty.ETC,
+                List.of(),
+                List.of(),
+                List.of(),
+                null);
     }
 
     public record IngredientParseResult(
             String name,
-            String amount,
+            Double amount,
             String unit
     ) {
 

--- a/src/main/java/com/shortkki/api/recipeImport/dto/RecipeParseResultResponse.java
+++ b/src/main/java/com/shortkki/api/recipeImport/dto/RecipeParseResultResponse.java
@@ -1,5 +1,8 @@
 package com.shortkki.api.recipeImport.dto;
 
+import com.shortkki.api.recipe.entity.CuisineType;
+import com.shortkki.api.recipe.entity.Difficulty;
+import com.shortkki.api.recipe.entity.MealType;
 import java.util.List;
 
 public record RecipeParseResultResponse(
@@ -7,11 +10,12 @@ public record RecipeParseResultResponse(
         String description,
         Integer servingSize,
         Integer cookingTime,
-        String cuisineType,
-        String mealType,
-        String difficulty,
+        CuisineType cuisineType,
+        MealType mealType,
+        Difficulty difficulty,
         List<IngredientDto> ingredients,
-        List<StepDto> steps
+        List<StepDto> steps,
+        List<String> tags
 ) {
 
     public static RecipeParseResultResponse from(RecipeParseResult parseResult) {
@@ -33,20 +37,24 @@ public record RecipeParseResultResponse(
                         .map(step -> new StepDto(
                                 step.stepNumber(),
                                 step.description()))
-                        .toList()
+                        .toList(),
+
+                parseResult.tags() != null ? parseResult.tags() : List.of()
         );
     }
 
     public record IngredientDto(
             String name,
-            String amount,
+            Double amount,
             String unit
     ) {
+
     }
 
     public record StepDto(
             int stepNumber,
             String description
     ) {
+
     }
 }

--- a/src/main/java/com/shortkki/api/recipeImport/service/RecipeImportAsyncService.java
+++ b/src/main/java/com/shortkki/api/recipeImport/service/RecipeImportAsyncService.java
@@ -19,6 +19,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class RecipeImportAsyncService {
 
+
     private final SourceContentRepository sourceContentRepository;
     private final MemberRepository memberRepository;
     private final SourceImportHistoryRepository sourceImportHistoryRepository;
@@ -54,7 +55,7 @@ public class RecipeImportAsyncService {
         try {
             history.updateStatus(ImportStatus.PARSING);
             sourceImportHistoryRepository.save(history);
-            
+
             log.info("AI 레시피 파싱 시작: {}", sourceUrl);
             parseResult = recipeParserPort.parseRecipeFromUrl(sourceUrl);
             aiRawResponse = parseResult.rawResponse();
@@ -63,11 +64,12 @@ public class RecipeImportAsyncService {
                     parseResult.ingredients().size(),
                     parseResult.steps().size());
         } catch (Exception e) {
+
             history.fail("AI parsing failed: " + e.getMessage(), aiRawResponse);
             sourceImportHistoryRepository.save(history);
             return;
         }
-
+        // TODO : 예외 발생한 PARSING 상태된 기록 정리
         try {
             String parsedContentJson = objectMapper.writeValueAsString(parseResult);
             history.markAsParsed(aiRawResponse, parsedContentJson);
@@ -82,4 +84,3 @@ public class RecipeImportAsyncService {
     }
 }
 
-// TODO : 예외 발생한 PARSING 상태된 기록 정리

--- a/src/main/java/com/shortkki/api/recipeImport/service/RecipeImportAsyncService.java
+++ b/src/main/java/com/shortkki/api/recipeImport/service/RecipeImportAsyncService.java
@@ -54,6 +54,7 @@ public class RecipeImportAsyncService {
         try {
             history.updateStatus(ImportStatus.PARSING);
             sourceImportHistoryRepository.save(history);
+            
             log.info("AI 레시피 파싱 시작: {}", sourceUrl);
             parseResult = recipeParserPort.parseRecipeFromUrl(sourceUrl);
             aiRawResponse = parseResult.rawResponse();
@@ -67,7 +68,6 @@ public class RecipeImportAsyncService {
             return;
         }
 
-        // Store parsed result as JSON for user review and editing
         try {
             String parsedContentJson = objectMapper.writeValueAsString(parseResult);
             history.markAsParsed(aiRawResponse, parsedContentJson);
@@ -81,3 +81,5 @@ public class RecipeImportAsyncService {
         }
     }
 }
+
+// TODO : 예외 발생한 PARSING 상태된 기록 정리

--- a/src/main/java/com/shortkki/api/recipeImport/service/RecipeImportService.java
+++ b/src/main/java/com/shortkki/api/recipeImport/service/RecipeImportService.java
@@ -1,18 +1,19 @@
 package com.shortkki.api.recipeImport.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.shortkki.api.member.entity.Member;
 import com.shortkki.api.member.repository.MemberRepository;
 import com.shortkki.api.recipe.entity.CuisineType;
 import com.shortkki.api.recipe.entity.Difficulty;
 import com.shortkki.api.recipe.entity.MealType;
+import com.shortkki.api.recipe.entity.Recipe;
 import com.shortkki.api.recipeImport.dto.RecipeEditRequest;
-import com.shortkki.api.recipeImport.dto.RecipeImportRequest;
 import com.shortkki.api.recipeImport.dto.RecipeImportPreview;
+import com.shortkki.api.recipeImport.dto.RecipeImportRequest;
 import com.shortkki.api.recipeImport.dto.RecipeImportResponse;
 import com.shortkki.api.recipeImport.dto.RecipeImportStatusResponse;
 import com.shortkki.api.recipeImport.dto.RecipeParseResult;
 import com.shortkki.api.recipeImport.dto.RecipeParseResultResponse;
-import com.shortkki.api.recipe.entity.Recipe;
 import com.shortkki.api.recipeBook.service.RecipeBookQueryService;
 import com.shortkki.api.recipeBook.service.RecipeBookService;
 import com.shortkki.api.source.domain.ImportStatus;
@@ -29,6 +30,7 @@ import com.shortkki.global.error.exception.BadRequestException;
 import com.shortkki.global.error.exception.BusinessException;
 import com.shortkki.global.error.exception.NotFoundException;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,7 +48,7 @@ public class RecipeImportService {
     private final RecipeImportTransactionalService transactionalService;
     private final RecipeBookService recipeBookService;
     private final RecipeBookQueryService recipeBookQueryService;
-    private final com.fasterxml.jackson.databind.ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
 
     @Transactional
     public RecipeImportResponse importFromUrl(Long memberId, RecipeImportRequest request) {
@@ -57,107 +59,80 @@ public class RecipeImportService {
 
         SourceContent sourceContent = sourceContentService.resolveSourceContent(sourceUrl);
 
-        SourceImportHistory history = SourceImportHistory.create(
-                member.getId(),
-                sourceContent.getId(),
-                sourceUrl,
-                sourceContent.getPlatform());
-        sourceImportHistoryRepository.save(history);
+        SourceImportHistory history = createHistory(member, sourceContent, sourceUrl);
+        RecipeImportPreview preview = loadPreview(sourceContent.getId());
 
-        SourceContent previewContent = sourceContentRepository.findByIdWithCreator(
-                        sourceContent.getId())
-                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_ERROR));
-        RecipeImportPreview preview = RecipeImportPreview.from(previewContent);
-
-        recipeImportAsyncService.processImport(
-                member.getId(),
-                sourceContent.getId(),
-                history.getId(),
-                sourceUrl);
+        recipeImportAsyncService.processImport(member.getId(), sourceContent.getId(),
+                history.getId(), sourceUrl);
 
         return RecipeImportResponse.accepted(history.getId(), sourceUrl, preview);
     }
 
     public RecipeImportStatusResponse getStatus(Long memberId, Long historyId) {
-        SourceImportHistory history = sourceImportHistoryRepository.findById(historyId)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_ERROR));
-
+        SourceImportHistory history = findHistory(historyId);
         validateHistoryOwnership(history, memberId);
 
-        SourceContent previewContent = sourceContentRepository.findByIdWithCreator(
-                        history.getSourceContentId())
-                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_ERROR));
-        RecipeImportPreview preview = RecipeImportPreview.from(previewContent);
-
+        RecipeImportPreview preview = loadPreview(history.getSourceContentId());
         return RecipeImportStatusResponse.from(history, preview);
     }
 
     public RecipeParseResultResponse getParsedRecipe(Long memberId, Long historyId) {
-        SourceImportHistory history = sourceImportHistoryRepository.findById(historyId)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_ERROR));
-
+        SourceImportHistory history = findHistory(historyId);
         validateHistoryOwnership(history, memberId);
+        validateStatusParsed(history);
+        validateParsedContentExists(history);
 
-        if (history.getStatus() != ImportStatus.PARSED) {
-            throw new BadRequestException(ErrorCode.INVALID_INPUT_VALUE);
-        }
-
-        if (history.getParsedContent() == null) {
-            throw new NotFoundException(ErrorCode.NOT_FOUND_ERROR);
-        }
-
-        try {
-            RecipeParseResult parseResult = objectMapper.readValue(
-                    history.getParsedContent(),
-                    RecipeParseResult.class);
-            return RecipeParseResultResponse.from(parseResult);
-        } catch (Exception e) {
-            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR,
-                    "파싱된 레시피 데이터를 읽는 중 오류가 발생했습니다.");
-        }
+        RecipeParseResult parseResult = readParseResult(history.getParsedContent());
+        return RecipeParseResultResponse.from(parseResult);
     }
 
     @Transactional
     public Long confirmAndSave(Long memberId, Long historyId, RecipeEditRequest request) {
-        SourceImportHistory history = sourceImportHistoryRepository.findById(historyId)
-                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_ERROR));
-
+        SourceImportHistory history = findHistory(historyId);
         validateHistoryOwnership(history, memberId);
-
-        if (history.getStatus() != ImportStatus.PARSED) {
-            throw new BadRequestException(ErrorCode.INVALID_INPUT_VALUE);
-        }
+        validateStatusParsed(history);
 
         Member member = findMemberById(memberId);
-        SourceContent sourceContent = sourceContentRepository.findById(history.getSourceContentId())
-                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_ERROR));
+        SourceContent sourceContent = findSourceContent(history.getSourceContentId());
 
+        Set<String> originalParsedTags = extractOriginalTags(history);
         RecipeParseResult parseResult = convertToParseResult(request);
+        Recipe savedRecipe = saveRecipe(member, sourceContent, parseResult, originalParsedTags);
 
-        Recipe savedRecipe;
-        try {
-            savedRecipe = transactionalService.saveRecipeWithRelations(member, sourceContent,
-                    parseResult);
-        } catch (Exception e) {
-            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR,
-                    "레시피 저장 중 오류가 발생했습니다: " + e.getMessage());
-        }
-
-        // history.updateRecipeId(savedRecipe.getId());
-        history.complete(savedRecipe.getId());
-        sourceImportHistoryRepository.save(history);
-
-        recipeBookQueryService.findDefaultByMemberId(memberId)
-                .ifPresent(defaultBook -> recipeBookService.addRecipeIfNotExists(
-                        memberId, defaultBook.getId(), savedRecipe.getId()));
+        completeHistory(history, savedRecipe.getId());
+        addToDefaultRecipeBook(memberId, savedRecipe.getId());
 
         return savedRecipe.getId();
     }
+
+    // -------------------------
+    // Helper methods (query)
+    // -------------------------
 
     private Member findMemberById(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
     }
+
+    private SourceImportHistory findHistory(Long historyId) {
+        return sourceImportHistoryRepository.findById(historyId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_ERROR));
+    }
+
+    private SourceContent findSourceContent(Long sourceContentId) {
+        return sourceContentRepository.findById(sourceContentId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_ERROR));
+    }
+
+    private RecipeImportPreview loadPreview(Long sourceContentId) {
+        SourceContent previewContent = sourceContentRepository.findByIdWithCreator(sourceContentId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_ERROR));
+        return RecipeImportPreview.from(previewContent);
+    }
+
+    // -------------------------
+    // Helper methods (validation)
+    // -------------------------
 
     private void validateNotDuplicateSource(String sourceUrl) {
         SourcePlatform platform = extractorRegistry.detectPlatform(sourceUrl)
@@ -175,6 +150,99 @@ public class RecipeImportService {
             throw new AccessDeniedException(ErrorCode.ACCESS_DENIED);
         }
     }
+
+    private void validateStatusParsed(SourceImportHistory history) {
+        if (history.getStatus() != ImportStatus.PARSED) {
+            throw new BadRequestException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+    }
+
+    private void validateParsedContentExists(SourceImportHistory history) {
+        if (history.getParsedContent() == null) {
+            throw new NotFoundException(ErrorCode.NOT_FOUND_ERROR);
+        }
+    }
+
+    private Set<String> extractOriginalTags(SourceImportHistory history) {
+        String parsedContent = history.getParsedContent();
+        if (parsedContent == null || parsedContent.isBlank()) {
+            return Set.of();
+        }
+
+        try {
+            RecipeParseResult parsed = objectMapper.readValue(parsedContent,
+                    RecipeParseResult.class);
+            List<String> tags = parsed.tags();
+            if (tags == null || tags.isEmpty()) {
+                return Set.of();
+            }
+
+            return tags.stream()
+                    .filter(t -> t != null && !t.isBlank())
+                    .map(String::trim)
+                    .collect(java.util.stream.Collectors.toSet());
+        } catch (Exception e) {
+            return Set.of();
+        }
+    }
+
+    // -------------------------
+    // Helper methods (commands)
+    // -------------------------
+
+    private SourceImportHistory createHistory(Member member, SourceContent sourceContent,
+            String sourceUrl) {
+        SourceImportHistory history = SourceImportHistory.create(
+                member.getId(),
+                sourceContent.getId(),
+                sourceUrl,
+                sourceContent.getPlatform()
+        );
+        return sourceImportHistoryRepository.save(history);
+    }
+
+    private RecipeParseResult readParseResult(String json) {
+        try {
+            return objectMapper.readValue(json, RecipeParseResult.class);
+        } catch (Exception e) {
+            throw new BusinessException(
+                    ErrorCode.INTERNAL_SERVER_ERROR,
+                    "파싱된 레시피 데이터를 읽는 중 오류가 발생했습니다."
+            );
+        }
+    }
+
+    private Recipe saveRecipe(Member member, SourceContent sourceContent,
+            RecipeParseResult parseResult,
+            Set<String> originalParsedTags
+    ) {
+        try {
+            return transactionalService.saveRecipeWithRelations(member, sourceContent, parseResult,
+                    originalParsedTags);
+        } catch (Exception e) {
+            throw new BusinessException(
+                    ErrorCode.INTERNAL_SERVER_ERROR,
+                    "레시피 저장 중 오류가 발생했습니다: " + e.getMessage()
+            );
+        }
+    }
+
+    private void completeHistory(SourceImportHistory history, Long recipeId) {
+        history.complete(recipeId);
+        sourceImportHistoryRepository.save(history);
+    }
+
+    private void addToDefaultRecipeBook(Long memberId, Long recipeId) {
+        recipeBookQueryService.findDefaultByMemberId(memberId)
+                .ifPresent(defaultBook ->
+                        recipeBookService.addRecipeIfNotExists(memberId, defaultBook.getId(),
+                                recipeId)
+                );
+    }
+
+    // -------------------------
+    // Conversion
+    // -------------------------
 
     private RecipeParseResult convertToParseResult(RecipeEditRequest request) {
         var ingredients = request.ingredients().stream()

--- a/src/main/java/com/shortkki/api/recipeImport/service/RecipeImportService.java
+++ b/src/main/java/com/shortkki/api/recipeImport/service/RecipeImportService.java
@@ -34,6 +34,8 @@ import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Service
 @RequiredArgsConstructor
@@ -62,8 +64,17 @@ public class RecipeImportService {
         SourceImportHistory history = createHistory(member, sourceContent, sourceUrl);
         RecipeImportPreview preview = loadPreview(sourceContent.getId());
 
-        recipeImportAsyncService.processImport(member.getId(), sourceContent.getId(),
-                history.getId(), sourceUrl);
+        Long resolvedMemberId = member.getId();
+        Long resolvedSourceContentId = sourceContent.getId();
+        Long resolvedHistoryId = history.getId();
+        TransactionSynchronizationManager.registerSynchronization(
+                new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        recipeImportAsyncService.processImport(
+                                resolvedMemberId, resolvedSourceContentId, resolvedHistoryId, sourceUrl);
+                    }
+                });
 
         return RecipeImportResponse.accepted(history.getId(), sourceUrl, preview);
     }

--- a/src/main/java/com/shortkki/api/recipeImport/service/RecipeImportService.java
+++ b/src/main/java/com/shortkki/api/recipeImport/service/RecipeImportService.java
@@ -2,6 +2,9 @@ package com.shortkki.api.recipeImport.service;
 
 import com.shortkki.api.member.entity.Member;
 import com.shortkki.api.member.repository.MemberRepository;
+import com.shortkki.api.recipe.entity.CuisineType;
+import com.shortkki.api.recipe.entity.Difficulty;
+import com.shortkki.api.recipe.entity.MealType;
 import com.shortkki.api.recipeImport.dto.RecipeEditRequest;
 import com.shortkki.api.recipeImport.dto.RecipeImportRequest;
 import com.shortkki.api.recipeImport.dto.RecipeImportPreview;
@@ -25,6 +28,7 @@ import com.shortkki.global.error.exception.AccessDeniedException;
 import com.shortkki.global.error.exception.BadRequestException;
 import com.shortkki.global.error.exception.BusinessException;
 import com.shortkki.global.error.exception.NotFoundException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -78,9 +82,7 @@ public class RecipeImportService {
         SourceImportHistory history = sourceImportHistoryRepository.findById(historyId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_FOUND_ERROR));
 
-        if (history.getMemberId() == null || !history.getMemberId().equals(memberId)) {
-            throw new AccessDeniedException(ErrorCode.ACCESS_DENIED);
-        }
+        validateHistoryOwnership(history, memberId);
 
         SourceContent previewContent = sourceContentRepository.findByIdWithCreator(
                         history.getSourceContentId())
@@ -178,8 +180,8 @@ public class RecipeImportService {
         var ingredients = request.ingredients().stream()
                 .map(ing -> new RecipeParseResult.IngredientParseResult(
                         ing.name(),
-                        ing.unit(),
-                        ing.amount()))
+                        ing.amount(),
+                        ing.unit()))
                 .toList();
 
         var steps = request.steps().stream()
@@ -193,12 +195,24 @@ public class RecipeImportService {
                 request.description(),
                 request.servingSize(),
                 request.cookingTime(),
-                request.cuisineType(),
-                request.mealType(),
-                request.difficulty(),
+                parseEnum(request.cuisineType(), CuisineType.ETC, CuisineType.class),
+                parseEnum(request.mealType(), MealType.ETC, MealType.class),
+                parseEnum(request.difficulty(), Difficulty.ETC, Difficulty.class),
                 ingredients,
                 steps,
+                request.tags() != null ? request.tags() : List.of(),
                 null
         );
+    }
+
+    private <E extends Enum<E>> E parseEnum(String value, E fallback, Class<E> enumType) {
+        if (value == null || value.isBlank()) {
+            return fallback;
+        }
+        try {
+            return Enum.valueOf(enumType, value.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return fallback;
+        }
     }
 }

--- a/src/main/java/com/shortkki/api/recipeImport/service/RecipeImportService.java
+++ b/src/main/java/com/shortkki/api/recipeImport/service/RecipeImportService.java
@@ -44,6 +44,7 @@ public class RecipeImportService {
     private final RecipeBookQueryService recipeBookQueryService;
     private final com.fasterxml.jackson.databind.ObjectMapper objectMapper;
 
+    @Transactional
     public RecipeImportResponse importFromUrl(Long memberId, RecipeImportRequest request) {
         Member member = findMemberById(memberId);
         String sourceUrl = request.sourceUrl();
@@ -140,8 +141,8 @@ public class RecipeImportService {
                     "레시피 저장 중 오류가 발생했습니다: " + e.getMessage());
         }
 
-        history.updateRecipeId(savedRecipe.getId());
-        history.complete(history.getRawResponse());
+        // history.updateRecipeId(savedRecipe.getId());
+        history.complete(savedRecipe.getId());
         sourceImportHistoryRepository.save(history);
 
         recipeBookQueryService.findDefaultByMemberId(memberId)

--- a/src/main/java/com/shortkki/api/recipeImport/service/RecipeImportTransactionalService.java
+++ b/src/main/java/com/shortkki/api/recipeImport/service/RecipeImportTransactionalService.java
@@ -9,7 +9,6 @@ import com.shortkki.api.recipe.entity.Recipe;
 import com.shortkki.api.recipe.entity.RecipeIngredient;
 import com.shortkki.api.recipe.entity.RecipeStep;
 import com.shortkki.api.recipe.entity.RecipeTag;
-import com.shortkki.api.recipe.entity.Tag;
 import com.shortkki.api.recipe.entity.TagSource;
 import com.shortkki.api.recipe.entity.vo.RecipeBasicInfo;
 import com.shortkki.api.recipe.entity.vo.RecipeCategoryInfo;
@@ -17,8 +16,8 @@ import com.shortkki.api.recipe.repository.RecipeIngredientRepository;
 import com.shortkki.api.recipe.repository.RecipeRepository;
 import com.shortkki.api.recipe.repository.RecipeStepRepository;
 import com.shortkki.api.recipe.repository.RecipeTagRepository;
-import com.shortkki.api.recipe.repository.TagRepository;
 import com.shortkki.api.recipe.service.IngredientQueryService;
+import com.shortkki.api.recipe.service.TagService;
 import com.shortkki.api.recipeImport.dto.RecipeParseResult;
 import com.shortkki.api.recipeImport.dto.RecipeParseResult.IngredientParseResult;
 import com.shortkki.api.recipeImport.dto.RecipeParseResult.StepParseResult;
@@ -27,7 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,7 +39,7 @@ public class RecipeImportTransactionalService {
 
     private final IngredientQueryService ingredientQueryService;
 
-    private final TagRepository tagRepository;
+    private final TagService tagService;
     private final RecipeTagRepository recipeTagRepository;
 
     @Transactional
@@ -114,13 +112,12 @@ public class RecipeImportTransactionalService {
             return;
         }
 
-        Set<String> original = normalizeTagSet(originalParsedTags);
+        Set<String> original = (originalParsedTags != null) ? originalParsedTags : Set.of();
 
         List<RecipeTag> recipeTags = new ArrayList<>(normalized.size());
         for (String name : normalized) {
             TagSource source = original.contains(name) ? TagSource.SYSTEM : TagSource.USER;
-            Tag tag = getOrCreateTag(name, source);
-            recipeTags.add(RecipeTag.of(recipe.getId(), tag.getId()));
+            recipeTags.add(RecipeTag.of(recipe.getId(), tagService.getOrCreateTag(name, source).getId()));
         }
 
         recipeTagRepository.saveAll(recipeTags);
@@ -132,30 +129,6 @@ public class RecipeImportTransactionalService {
                 .map(String::trim)
                 .distinct()
                 .toList();
-    }
-
-    private Set<String> normalizeTagSet(Set<String> tags) {
-        if (tags == null || tags.isEmpty()) {
-            return Set.of();
-        }
-        return tags.stream()
-                .filter(t -> t != null && !t.isBlank())
-                .map(String::trim)
-                .collect(java.util.stream.Collectors.toSet());
-    }
-
-    private Tag getOrCreateTag(String name, TagSource source) {
-        try {
-            return tagRepository.findByName(name)
-                    .orElseGet(() -> {
-                        Tag newTag = (source == TagSource.SYSTEM)
-                                ? Tag.createSystemTag(name)
-                                : Tag.createUserTag(name);
-                        return tagRepository.save(newTag);
-                    });
-        } catch (DataIntegrityViolationException e) { // 동시성 경합 대비
-            return tagRepository.findByName(name).orElseThrow(() -> e);
-        }
     }
 
     private String normalizeText(String s) {

--- a/src/main/java/com/shortkki/api/recipeImport/service/RecipeImportTransactionalService.java
+++ b/src/main/java/com/shortkki/api/recipeImport/service/RecipeImportTransactionalService.java
@@ -29,35 +29,38 @@ import org.springframework.transaction.annotation.Transactional;
 public class RecipeImportTransactionalService {
 
     private final RecipeRepository recipeRepository;
-    private final IngredientRepository ingredientRepository;
     private final RecipeIngredientRepository recipeIngredientRepository;
     private final RecipeStepRepository recipeStepRepository;
 
     private final IngredientQueryService ingredientQueryService;
 
-
-    @Transactional
+    
     public Recipe saveRecipeWithRelations(
             Member member,
             SourceContent sourceContent,
-            RecipeParseResult parseResult) {
+            RecipeParseResult parseResult
+    ) {
         Recipe recipe = saveRecipe(member, sourceContent, parseResult);
-        saveIngredients(recipe, parseResult.ingredients());
-        saveSteps(recipe, parseResult.steps());
+
+        saveIngredients(recipe,
+                parseResult.ingredients() == null ? List.of() : parseResult.ingredients());
+        saveSteps(recipe, parseResult.steps() == null ? List.of() : parseResult.steps());
+
         return recipe;
     }
 
     private Recipe saveRecipe(Member member, SourceContent sourceContent,
-            RecipeParseResult parseResult) {
+            RecipeParseResult parseResult
+    ) {
         RecipeBasicInfo basicInfo = new RecipeBasicInfo(
                 parseResult.title() != null ? parseResult.title() : sourceContent.getTitle(),
                 parseResult.description(),
                 parseResult.servingSize() != null ? parseResult.servingSize() : 1,
                 parseResult.cookingTime() != null ? parseResult.cookingTime() : 0);
 
-        CuisineType cuisineType = parseCuisineType(parseResult.cuisineType());
-        MealType mealType = parseMealType(parseResult.mealType());
-        Difficulty difficulty = parseDifficulty(parseResult.difficulty());
+        CuisineType cuisineType = parseEnum(parseResult.cuisineType(), CuisineType.class);
+        MealType mealType = parseEnum(parseResult.mealType(), MealType.class);
+        Difficulty difficulty = parseEnum(parseResult.difficulty(), Difficulty.class);
 
         RecipeCategoryInfo categoryInfo = new RecipeCategoryInfo(
                 cuisineType != null ? cuisineType : CuisineType.ETC,
@@ -69,6 +72,7 @@ public class RecipeImportTransactionalService {
                 basicInfo,
                 categoryInfo,
                 sourceContent);
+
         return recipeRepository.save(recipe);
     }
 
@@ -112,34 +116,12 @@ public class RecipeImportTransactionalService {
         }
     }
 
-    private CuisineType parseCuisineType(String value) {
-        if (value == null) {
+    private <T extends Enum<T>> T parseEnum(String value, Class<T> enumType) {
+        if (value == null || value.isBlank()) {
             return null;
         }
         try {
-            return CuisineType.valueOf(value);
-        } catch (IllegalArgumentException e) {
-            return null;
-        }
-    }
-
-    private MealType parseMealType(String value) {
-        if (value == null) {
-            return null;
-        }
-        try {
-            return MealType.valueOf(value);
-        } catch (IllegalArgumentException e) {
-            return null;
-        }
-    }
-
-    private Difficulty parseDifficulty(String value) {
-        if (value == null) {
-            return null;
-        }
-        try {
-            return Difficulty.valueOf(value);
+            return Enum.valueOf(enumType, value.trim());
         } catch (IllegalArgumentException e) {
             return null;
         }

--- a/src/main/java/com/shortkki/api/recipeImport/service/RecipeImportTransactionalService.java
+++ b/src/main/java/com/shortkki/api/recipeImport/service/RecipeImportTransactionalService.java
@@ -10,6 +10,7 @@ import com.shortkki.api.recipe.entity.RecipeIngredient;
 import com.shortkki.api.recipe.entity.RecipeStep;
 import com.shortkki.api.recipe.entity.RecipeTag;
 import com.shortkki.api.recipe.entity.Tag;
+import com.shortkki.api.recipe.entity.TagSource;
 import com.shortkki.api.recipe.entity.vo.RecipeBasicInfo;
 import com.shortkki.api.recipe.entity.vo.RecipeCategoryInfo;
 import com.shortkki.api.recipe.repository.RecipeIngredientRepository;
@@ -24,6 +25,7 @@ import com.shortkki.api.recipeImport.dto.RecipeParseResult.StepParseResult;
 import com.shortkki.api.source.domain.SourceContent;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -43,13 +45,17 @@ public class RecipeImportTransactionalService {
     private final RecipeTagRepository recipeTagRepository;
 
     @Transactional
-    public Recipe saveRecipeWithRelations(Member member, SourceContent sourceContent,
-            RecipeParseResult parseResult) {
+    public Recipe saveRecipeWithRelations(
+            Member member,
+            SourceContent sourceContent,
+            RecipeParseResult parseResult,
+            Set<String> originalParsedTags
+    ) {
         Recipe recipe = saveRecipe(member, sourceContent, parseResult);
 
         saveIngredients(recipe, safeList(parseResult.ingredients()));
         saveSteps(recipe, safeList(parseResult.steps()));
-        saveTags(recipe, safeList(parseResult.tags()));
+        saveTags(recipe, safeList(parseResult.tags()), originalParsedTags);
 
         return recipe;
     }
@@ -76,6 +82,7 @@ public class RecipeImportTransactionalService {
 
     private void saveIngredients(Recipe recipe, List<IngredientParseResult> ingredients) {
         List<RecipeIngredient> entities = ingredients.stream()
+                .filter(ing -> ing.name() != null && !ing.name().isBlank()) // ✅ 빈 이름 필터
                 .map(ing -> toRecipeIngredient(recipe, ing))
                 .toList();
 
@@ -101,15 +108,18 @@ public class RecipeImportTransactionalService {
         }
     }
 
-    private void saveTags(Recipe recipe, List<String> tags) {
+    private void saveTags(Recipe recipe, List<String> tags, Set<String> originalParsedTags) {
         List<String> normalized = normalizeTags(tags);
         if (normalized.isEmpty()) {
             return;
         }
 
+        Set<String> original = normalizeTagSet(originalParsedTags);
+
         List<RecipeTag> recipeTags = new ArrayList<>(normalized.size());
         for (String name : normalized) {
-            Tag tag = getOrCreateSystemTag(name);
+            TagSource source = original.contains(name) ? TagSource.SYSTEM : TagSource.USER;
+            Tag tag = getOrCreateTag(name, source);
             recipeTags.add(RecipeTag.of(recipe.getId(), tag.getId()));
         }
 
@@ -124,11 +134,26 @@ public class RecipeImportTransactionalService {
                 .toList();
     }
 
-    private Tag getOrCreateSystemTag(String name) {
+    private Set<String> normalizeTagSet(Set<String> tags) {
+        if (tags == null || tags.isEmpty()) {
+            return Set.of();
+        }
+        return tags.stream()
+                .filter(t -> t != null && !t.isBlank())
+                .map(String::trim)
+                .collect(java.util.stream.Collectors.toSet());
+    }
+
+    private Tag getOrCreateTag(String name, TagSource source) {
         try {
             return tagRepository.findByName(name)
-                    .orElseGet(() -> tagRepository.save(Tag.createSystemTag(name)));
-        } catch (DataIntegrityViolationException e) {   // 동시성 해결 위해
+                    .orElseGet(() -> {
+                        Tag newTag = (source == TagSource.SYSTEM)
+                                ? Tag.createSystemTag(name)
+                                : Tag.createUserTag(name);
+                        return tagRepository.save(newTag);
+                    });
+        } catch (DataIntegrityViolationException e) { // 동시성 경합 대비
             return tagRepository.findByName(name).orElseThrow(() -> e);
         }
     }

--- a/src/main/java/com/shortkki/api/recipeImport/service/RecipeImportTransactionalService.java
+++ b/src/main/java/com/shortkki/api/recipeImport/service/RecipeImportTransactionalService.java
@@ -1,7 +1,6 @@
 package com.shortkki.api.recipeImport.service;
 
 import com.shortkki.api.ingredient.entity.Ingredient;
-import com.shortkki.api.ingredient.repository.IngredientRepository;
 import com.shortkki.api.member.entity.Member;
 import com.shortkki.api.recipe.entity.CuisineType;
 import com.shortkki.api.recipe.entity.Difficulty;
@@ -9,18 +8,24 @@ import com.shortkki.api.recipe.entity.MealType;
 import com.shortkki.api.recipe.entity.Recipe;
 import com.shortkki.api.recipe.entity.RecipeIngredient;
 import com.shortkki.api.recipe.entity.RecipeStep;
+import com.shortkki.api.recipe.entity.RecipeTag;
+import com.shortkki.api.recipe.entity.Tag;
 import com.shortkki.api.recipe.entity.vo.RecipeBasicInfo;
 import com.shortkki.api.recipe.entity.vo.RecipeCategoryInfo;
 import com.shortkki.api.recipe.repository.RecipeIngredientRepository;
 import com.shortkki.api.recipe.repository.RecipeRepository;
 import com.shortkki.api.recipe.repository.RecipeStepRepository;
+import com.shortkki.api.recipe.repository.RecipeTagRepository;
+import com.shortkki.api.recipe.repository.TagRepository;
 import com.shortkki.api.recipe.service.IngredientQueryService;
 import com.shortkki.api.recipeImport.dto.RecipeParseResult;
 import com.shortkki.api.recipeImport.dto.RecipeParseResult.IngredientParseResult;
 import com.shortkki.api.recipeImport.dto.RecipeParseResult.StepParseResult;
 import com.shortkki.api.source.domain.SourceContent;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,96 +39,113 @@ public class RecipeImportTransactionalService {
 
     private final IngredientQueryService ingredientQueryService;
 
-    
-    public Recipe saveRecipeWithRelations(
-            Member member,
-            SourceContent sourceContent,
-            RecipeParseResult parseResult
-    ) {
+    private final TagRepository tagRepository;
+    private final RecipeTagRepository recipeTagRepository;
+
+    @Transactional
+    public Recipe saveRecipeWithRelations(Member member, SourceContent sourceContent,
+            RecipeParseResult parseResult) {
         Recipe recipe = saveRecipe(member, sourceContent, parseResult);
 
-        saveIngredients(recipe,
-                parseResult.ingredients() == null ? List.of() : parseResult.ingredients());
-        saveSteps(recipe, parseResult.steps() == null ? List.of() : parseResult.steps());
+        saveIngredients(recipe, safeList(parseResult.ingredients()));
+        saveSteps(recipe, safeList(parseResult.steps()));
+        saveTags(recipe, safeList(parseResult.tags()));
 
         return recipe;
     }
 
     private Recipe saveRecipe(Member member, SourceContent sourceContent,
-            RecipeParseResult parseResult
-    ) {
+            RecipeParseResult parseResult) {
         RecipeBasicInfo basicInfo = new RecipeBasicInfo(
-                parseResult.title() != null ? parseResult.title() : sourceContent.getTitle(),
-                parseResult.description(),
-                parseResult.servingSize() != null ? parseResult.servingSize() : 1,
-                parseResult.cookingTime() != null ? parseResult.cookingTime() : 0);
-
-        CuisineType cuisineType = parseEnum(parseResult.cuisineType(), CuisineType.class);
-        MealType mealType = parseEnum(parseResult.mealType(), MealType.class);
-        Difficulty difficulty = parseEnum(parseResult.difficulty(), Difficulty.class);
+                orDefault(parseResult.title(), sourceContent.getTitle()),
+                orDefault(parseResult.description(), ""),
+                orDefault(parseResult.servingSize(), 1),
+                orDefault(parseResult.cookingTime(), 0)
+        );
 
         RecipeCategoryInfo categoryInfo = new RecipeCategoryInfo(
-                cuisineType != null ? cuisineType : CuisineType.ETC,
-                mealType != null ? mealType : MealType.ETC,
-                difficulty != null ? difficulty : Difficulty.ETC);
+                orDefault(parseResult.cuisineType(), CuisineType.ETC),
+                orDefault(parseResult.mealType(), MealType.ETC),
+                orDefault(parseResult.difficulty(), Difficulty.ETC)
+        );
 
-        Recipe recipe = Recipe.createImported(
-                member,
-                basicInfo,
-                categoryInfo,
-                sourceContent);
-
-        return recipeRepository.save(recipe);
+        return recipeRepository.save(
+                Recipe.createImported(member, basicInfo, categoryInfo, sourceContent)
+        );
     }
 
     private void saveIngredients(Recipe recipe, List<IngredientParseResult> ingredients) {
         List<RecipeIngredient> entities = ingredients.stream()
-                .map(ing -> {
-
-                    String rawName = ing.name() == null ? "" : ing.name().trim();
-                    Ingredient ingredient = ingredientQueryService.findStandardByNameOrNull(
-                            rawName);
-                    String name = ingredient != null ? ingredient.getName() : rawName;
-
-                    Double amount = parseAmount(ing.amount());
-                    String unit = (ing.unit() != null && !ing.unit().isBlank())
-                            ? ing.unit().trim()
-                            : "단위없음";
-
-                    return RecipeIngredient.create(ingredient, recipe, name, amount, unit);
-                })
+                .map(ing -> toRecipeIngredient(recipe, ing))
                 .toList();
 
         recipeIngredientRepository.saveAll(entities);
     }
 
+    private RecipeIngredient toRecipeIngredient(Recipe recipe, IngredientParseResult ing) {
+        String rawName = normalizeText(ing.name());
+        Ingredient ingredient = ingredientQueryService.findStandardByNameOrNull(rawName);
+        String name = (ingredient != null) ? ingredient.getName() : rawName;
+
+        Double amount = ing.amount();
+        String unit = normalizeUnit(ing.unit());
+
+        return RecipeIngredient.create(ingredient, recipe, name, amount, unit);
+    }
+
     private void saveSteps(Recipe recipe, List<StepParseResult> steps) {
         for (StepParseResult step : steps) {
-            RecipeStep recipeStep = RecipeStep.create(
-                    recipe, step.stepNumber(), step.description());
-            recipeStepRepository.save(recipeStep);
+            recipeStepRepository.save(
+                    RecipeStep.create(recipe, step.stepNumber(), step.description())
+            );
         }
     }
 
-    private Double parseAmount(String amountStr) {
-        if (amountStr == null || amountStr.isBlank()) {
-            return null;
+    private void saveTags(Recipe recipe, List<String> tags) {
+        List<String> normalized = normalizeTags(tags);
+        if (normalized.isEmpty()) {
+            return;
         }
+
+        List<RecipeTag> recipeTags = new ArrayList<>(normalized.size());
+        for (String name : normalized) {
+            Tag tag = getOrCreateSystemTag(name);
+            recipeTags.add(RecipeTag.of(recipe.getId(), tag.getId()));
+        }
+
+        recipeTagRepository.saveAll(recipeTags);
+    }
+
+    private List<String> normalizeTags(List<String> tags) {
+        return safeList(tags).stream()
+                .filter(t -> t != null && !t.isBlank())
+                .map(String::trim)
+                .distinct()
+                .toList();
+    }
+
+    private Tag getOrCreateSystemTag(String name) {
         try {
-            return Double.parseDouble(amountStr);
-        } catch (NumberFormatException e) {
-            return null;
+            return tagRepository.findByName(name)
+                    .orElseGet(() -> tagRepository.save(Tag.createSystemTag(name)));
+        } catch (DataIntegrityViolationException e) {   // 동시성 해결 위해
+            return tagRepository.findByName(name).orElseThrow(() -> e);
         }
     }
 
-    private <T extends Enum<T>> T parseEnum(String value, Class<T> enumType) {
-        if (value == null || value.isBlank()) {
-            return null;
-        }
-        try {
-            return Enum.valueOf(enumType, value.trim());
-        } catch (IllegalArgumentException e) {
-            return null;
-        }
+    private String normalizeText(String s) {
+        return (s == null) ? "" : s.trim();
+    }
+
+    private String normalizeUnit(String unit) {
+        return (unit != null && !unit.isBlank()) ? unit.trim() : "단위없음";
+    }
+
+    private <T> List<T> safeList(List<T> list) {
+        return (list == null) ? List.of() : list;
+    }
+
+    private <T> T orDefault(T value, T defaultValue) {
+        return (value != null) ? value : defaultValue;
     }
 }

--- a/src/main/java/com/shortkki/api/source/domain/SourceImportHistory.java
+++ b/src/main/java/com/shortkki/api/source/domain/SourceImportHistory.java
@@ -42,10 +42,16 @@ public class SourceImportHistory extends BaseEntity {
     @Column(nullable = false, length = 30)
     private SourcePlatform platform;
 
+    /**
+     * 외부 응답 원본 문자열 - 파싱 성공/실패와 무관 - 디버깅 및 재처리 용도
+     */
     @Lob
     @Column(columnDefinition = "MEDIUMTEXT")
     private String rawResponse;
 
+    /**
+     * 파싱된 결과물 - PARSED 상태에서 존재 (사용자 확인/수정용) - COMPLETED 전환 시 정리(null)될 수 있음
+     */
     @Lob
     @Column(columnDefinition = "TEXT")
     private String parsedContent;
@@ -94,15 +100,27 @@ public class SourceImportHistory extends BaseEntity {
         this.rawResponse = rawResponse;
     }
 
+    /**
+     * 파싱 성공 - rawResponse / parsedContent 저장 - status = PARSED - errorMessage 정리
+     */
     public void markAsParsed(String rawResponse, String parsedContent) {
+        if (parsedContent == null || parsedContent.isBlank()) {
+            throw new IllegalArgumentException("파싱된 결과가 비어있지 않아야한다.");
+        }
         this.rawResponse = rawResponse;
         this.parsedContent = parsedContent;
+        this.errorMessage = null;
         this.status = ImportStatus.PARSED;
     }
 
-    public void complete(String rawResponse) {
-        this.rawResponse = rawResponse;
+    /**
+     * 저장 확정(최종 완료) - recipeId 기록 - status = COMPLETED - parsedContent 정리(요구사항) - errorMessage 정리
+     */
+    public void complete(Long recipeId) {
+        this.recipeId = recipeId;
         this.status = ImportStatus.COMPLETED;
+        this.errorMessage = null;
+        this.parsedContent = null;
     }
 
     public void updateRecipeId(Long recipeId) {
@@ -112,11 +130,13 @@ public class SourceImportHistory extends BaseEntity {
     public void fail(String errorMessage, String rawResponse) {
         this.errorMessage = errorMessage;
         this.rawResponse = rawResponse;
+        this.parsedContent = null;
         this.status = ImportStatus.FAILED;
     }
 
     public void fail(String errorMessage) {
         this.errorMessage = errorMessage;
+        this.parsedContent = null;
         this.status = ImportStatus.FAILED;
     }
 }

--- a/src/main/resources/prompts/recipe-parser-prompt.txt
+++ b/src/main/resources/prompts/recipe-parser-prompt.txt
@@ -14,7 +14,8 @@
     ],
     "steps": [
         {"stepNumber": 1, "description": "조리 과정 설명"}
-    ]
+    ],
+    "tags": ["김치찌개", "한식", "찌개", "집밥"]
 }
 
 중요한 가이드라인:
@@ -31,7 +32,13 @@
 - amount: 숫자만 작성 (예: "200", "2", "0.5")
 - unit: 단위만 작성 (예: "g", "큰술", "개", "ml", "컵")
 - amount와 unit을 반드시 분리해서 작성
-- 소수점 사용 가능 (예: amount="0.5", unit="큰술")
+- amount는 소수점 사용 가능 (예: amount="0.5", unit="큰술")
+
+*** 태그 형식 **
+- 요리의 특성, 장르 , 카테고리, 상황을 나타내는 키워드
+- 재료명 금지
+- 요리 분류 , 스타일, 종류 허용
+- 2~5개로 제한
 
 **기타:**
 - servingSize는 인분 수 (숫자만)
@@ -40,3 +47,8 @@
 - mealType: MAIN, SIDE_DISH, SNACK, DESSERT, SIDE_FOR_DRINK, ETC 중 하나
 - difficulty: BEGINNER, INTERMEDIATE, ADVANCED, ETC 중 하나
 - ingredients와 steps는 빠짐없이 추출
+
+** 데이터가 불확실한 경우**
+- 합리적인 일반 가정으로 보완
+- null 사용 금지
+- 필드는 반드시 포함

--- a/src/test/java/com/shortkki/api/recipeImport/service/parser/RecipeParseResultParsingTest.java
+++ b/src/test/java/com/shortkki/api/recipeImport/service/parser/RecipeParseResultParsingTest.java
@@ -1,6 +1,9 @@
 package com.shortkki.api.recipeImport.service.parser;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.shortkki.api.recipe.entity.CuisineType;
+import com.shortkki.api.recipe.entity.Difficulty;
+import com.shortkki.api.recipe.entity.MealType;
 import com.shortkki.api.recipeImport.dto.RecipeParseResult;
 import com.shortkki.api.recipeImport.dto.RecipeParseResult.IngredientParseResult;
 import com.shortkki.api.recipeImport.dto.RecipeParseResult.StepParseResult;
@@ -16,53 +19,7 @@ class RecipeParseResultParsingTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
-    @DisplayName("RecipeParseResult를 직접 파싱할 수 있는지 테스트 (rawResponse 필드 무시)")
-    void testDirectParsing() throws Exception {
-        // AI가 반환하는 JSON (rawResponse 필드 없음)
-        String aiJsonResponse = """
-                {
-                    "title": "김치찌개",
-                    "description": "맛있는 김치찌개",
-                    "servingSize": 2,
-                    "cookingTime": 30,
-                    "cuisineType": "KOREAN",
-                    "mealType": "MAIN",
-                    "difficulty": "BEGINNER",
-                    "ingredients": [
-                        {"name": "김치", "amount": "200g"},
-                        {"name": "돼지고기", "amount": "150g"}
-                    ],
-                    "steps": [
-                        {"stepNumber": 1, "description": "김치를 썬다"},
-                        {"stepNumber": 2, "description": "고기를 볶는다"}
-                    ]
-                }
-                """;
-
-        // RecipeParseResult를 직접 파싱 시도
-        RecipeParseResult result = objectMapper.readValue(aiJsonResponse, RecipeParseResult.class);
-
-        // 검증
-        assertThat(result).isNotNull();
-        assertThat(result.title()).isEqualTo("김치찌개");
-        assertThat(result.description()).isEqualTo("맛있는 김치찌개");
-        assertThat(result.servingSize()).isEqualTo(2);
-        assertThat(result.cookingTime()).isEqualTo(30);
-        assertThat(result.cuisineType()).isEqualTo("KOREAN");
-        assertThat(result.mealType()).isEqualTo("MAIN");
-        assertThat(result.difficulty()).isEqualTo("BEGINNER");
-        assertThat(result.ingredients()).hasSize(2);
-        assertThat(result.steps()).hasSize(2);
-
-        // rawResponse는 JSON에 없으므로 null이어야 함
-        assertThat(result.rawResponse()).isNull();
-
-        System.out.println("✅ RecipeParseResult 직접 파싱 성공!");
-        System.out.println("rawResponse: " + result.rawResponse());
-    }
-
-    @Test
-    @DisplayName("중간 DTO를 사용한 파싱 테스트")
+    @DisplayName("중간 DTO(String) 파싱 후 RecipeParseResult(enum)로 변환 테스트 (tags 포함)")
     void testIntermediateDtoParsing() throws Exception {
         String aiJsonResponse = """
                 {
@@ -74,41 +31,73 @@ class RecipeParseResultParsingTest {
                     "mealType": "MAIN",
                     "difficulty": "BEGINNER",
                     "ingredients": [
-                        {"name": "김치", "amount": "200g"}
+                        {"name": "김치", "amount": 200, "unit": "g"}
                     ],
                     "steps": [
                         {"stepNumber": 1, "description": "김치를 썬다"}
-                    ]
+                    ],
+                    "tags": ["김치찌개", "한식", "찌개"]
                 }
                 """;
 
-        // 중간 DTO로 파싱
-        RecipeParseResultDto dto = objectMapper.readValue(aiJsonResponse, RecipeParseResultDto.class);
+        RecipeParseResultDto dto = objectMapper.readValue(aiJsonResponse,
+                RecipeParseResultDto.class);
 
-        // rawResponse를 수동으로 추가하여 RecipeParseResult 생성
         String rawResponse = aiJsonResponse;
+
         RecipeParseResult result = new RecipeParseResult(
                 dto.title(),
                 dto.description(),
                 dto.servingSize(),
                 dto.cookingTime(),
-                dto.cuisineType(),
-                dto.mealType(),
-                dto.difficulty(),
+                toCuisineType(dto.cuisineType()),
+                toMealType(dto.mealType()),
+                toDifficulty(dto.difficulty()),
                 dto.ingredients(),
                 dto.steps(),
+                dto.tags() != null ? dto.tags() : List.of(),
                 rawResponse
         );
 
-        // 검증
+        assertThat(result).isNotNull();
+        assertThat(result.title()).isEqualTo("김치찌개");
+        assertThat(result.cuisineType()).isEqualTo(CuisineType.KOREAN);
+        assertThat(result.mealType()).isEqualTo(MealType.MAIN);
+        assertThat(result.difficulty()).isEqualTo(Difficulty.BEGINNER);
+        assertThat(result.ingredients()).hasSize(1);
+        assertThat(result.ingredients().get(0).amount()).isEqualTo(200.0);
+        assertThat(result.tags()).contains("김치찌개", "한식", "찌개");
         assertThat(result.rawResponse()).isNotNull();
-        assertThat(result.rawResponse()).contains("김치찌개");
 
         System.out.println("✅ 중간 DTO 파싱 성공!");
-        System.out.println("rawResponse가 정상적으로 설정됨: " + (result.rawResponse() != null));
     }
 
-    // AI 응답 JSON 구조와 일치하는 중간 record
+    private CuisineType toCuisineType(String value) {
+        try {
+            return value == null ? CuisineType.ETC
+                    : CuisineType.valueOf(value.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return CuisineType.ETC;
+        }
+    }
+
+    private MealType toMealType(String value) {
+        try {
+            return value == null ? MealType.ETC : MealType.valueOf(value.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return MealType.ETC;
+        }
+    }
+
+    private Difficulty toDifficulty(String value) {
+        try {
+            return value == null ? Difficulty.ETC : Difficulty.valueOf(value.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return Difficulty.ETC;
+        }
+    }
+
+    // AI 응답 JSON 구조와 일치하는 중간 record (문자열 enum + amount Double)
     private record RecipeParseResultDto(
             String title,
             String description,
@@ -118,6 +107,9 @@ class RecipeParseResultParsingTest {
             String mealType,
             String difficulty,
             List<IngredientParseResult> ingredients,
-            List<StepParseResult> steps
-    ) {}
+            List<StepParseResult> steps,
+            List<String> tags
+    ) {
+
+    }
 }


### PR DESCRIPTION
- RecipeBookItem 정합성 위해 유니크 제약조건
- BookmarkCount 증감 로직 적용

## 🔥 변경 사항
*이번 PR에서 변경된 핵심 내용 요약*
- 북마크수 증감 로직
- 유니크제약조건 설정

<br>

## 🧩 관련 이슈
- related to #37 
- closes #이슈번호

<br>

## 🛠 작업 내용

- [X] `Recipe` — `incrementBookmarkCount()`, `decrementBookmarkCount()` 메서드 추가 (decrement에 `> 0` guard)
- [X] `RecipeBookService.addRecipe()` — item 저장 후 `recipe.incrementBookmarkCount()`
- [X] `RecipeBookService.addRecipeIfNotExists()` — 실제 저장되는 경우에만 increment (early return 아닌 경로)
- [X] `RecipeBookService.removeRecipe()` — Recipe 엔티티 로드 추가 → `recipe.decrementBookmarkCount()`
- [X] `RecipeBookService.delete()` — items를 먼저 로드 → 각 recipe decrement → 그 후 bulk delete

<br>

## 📸 스크린샷 / 결과 (선택)
*UI 변경, API 응답 결과 등 첨부*

(내용)

<br>

## ⚠️ 참고 사항 (선택)
- 리뷰 참고 사항
- 중점 확인 사항
- 배포 영향 여부

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리즈 노트

* **개선 사항**
  * 북마크 카운트 증감 정확성 향상(음수 방지, 삭제/이동 시 일관 반영)
  * 외부 임포트 히스토리의 원본 응답 및 파싱 결과 저장·상태 관리 강화
  * AI 파싱 로깅·오류 처리 개선

* **신규 기능**
  * 레시피를 한 레시피북에서 다른 레시피북으로 이동하는 API 추가
  * 태그 관리 및 레시피-태그 연동 서비스 추가

* **데이터 모델 변경 (노출 영향)**
  * 파싱/응답에 태그 필드 추가 및 수량 소수 지원, 분류·난이도에 표준 enum 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->