### PR TITLE
fix : 장볼거리 추가 시 재료 이름으로 추가

### DIFF
--- a/src/main/java/com/shortkki/api/calendar/controller/GroupRecipeCalendarController.java
+++ b/src/main/java/com/shortkki/api/calendar/controller/GroupRecipeCalendarController.java
@@ -1,0 +1,32 @@
+package com.shortkki.api.calendar.controller;
+
+import com.shortkki.api.calendar.service.RecipeCalendarService;
+import com.shortkki.global.auth.dto.LoginMember;
+import com.shortkki.global.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/groups/{groupId}/calendar/recipes")
+@RequiredArgsConstructor
+public class GroupRecipeCalendarController {
+
+    private final RecipeCalendarService recipeCalendarService;
+
+    @Operation(summary = "그룹 레시피 캘린더 삭제")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<BaseResponse<Void>> deleteGroupCalendar(
+            @AuthenticationPrincipal LoginMember loginMember,
+            @PathVariable Long groupId,
+            @PathVariable Long id
+    ) {
+        recipeCalendarService.deleteGroupCalendar(loginMember.getId(), groupId, id);
+        return ResponseEntity.ok(BaseResponse.success("그룹 레시피 캘린더가 삭제되었습니다."));
+    }
+}

--- a/src/main/java/com/shortkki/api/calendar/controller/RecipeCalendarController.java
+++ b/src/main/java/com/shortkki/api/calendar/controller/RecipeCalendarController.java
@@ -67,13 +67,13 @@ public class RecipeCalendarController {
         return ResponseEntity.ok(BaseResponse.success("레시피 캘린더 순서가 변경되었습니다."));
     }
 
-    @Operation(summary = "레시피 캘린더 삭제")
+    @Operation(summary = "개인 레시피 캘린더 삭제")
     @DeleteMapping("/{id}")
-    public ResponseEntity<BaseResponse<Void>> delete(
+    public ResponseEntity<BaseResponse<Void>> deletePersonalCalendar(
             @AuthenticationPrincipal LoginMember loginMember,
             @PathVariable Long id
     ) {
-        recipeCalendarService.delete(loginMember.getId(), id);
+        recipeCalendarService.deletePersonalCalendar(loginMember.getId(), id);
         return ResponseEntity.ok(BaseResponse.success("레시피 캘린더가 삭제되었습니다."));
     }
 }

--- a/src/main/java/com/shortkki/api/calendar/repository/RecipeCalendarRepository.java
+++ b/src/main/java/com/shortkki/api/calendar/repository/RecipeCalendarRepository.java
@@ -1,13 +1,19 @@
 package com.shortkki.api.calendar.repository;
 
 import com.shortkki.api.calendar.entity.RecipeCalendar;
+import com.shortkki.api.group.entity.Group;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 
 import java.time.LocalDate;
 import org.springframework.data.jpa.repository.Query;
 
 public interface RecipeCalendarRepository extends JpaRepository<RecipeCalendar, Long>,
         RecipeCalendarRepositoryCustom {
+
+    @Modifying
+    @Query("DELETE FROM RecipeCalendar rc WHERE rc.group = :group")
+    void deleteAllByGroup(Group group);
 
     @Query("""
             select coalesce(max(rc.sortOrder), 0)

--- a/src/main/java/com/shortkki/api/calendar/service/RecipeCalendarService.java
+++ b/src/main/java/com/shortkki/api/calendar/service/RecipeCalendarService.java
@@ -57,10 +57,15 @@ public class RecipeCalendarService {
         return RecipeCalendarDetailResponse.from(calendar);
     }
 
-    public void delete(Long memberId, Long calendarId) {
+    public void deletePersonalCalendar(Long memberId, Long calendarId) {
         RecipeCalendar calendar = recipeCalendarQueryService.findRecipeCalendar(calendarId);
-        recipeCalendarValidationService.validateRecipeCalendarOwner(calendarId, memberId);
+        recipeCalendarValidationService.validatePersonalCalendarOwner(calendar, memberId);
+        recipeCalendarRepository.delete(calendar);
+    }
 
+    public void deleteGroupCalendar(Long memberId, Long groupId, Long calendarId) {
+        RecipeCalendar calendar = recipeCalendarQueryService.findRecipeCalendar(calendarId);
+        recipeCalendarValidationService.validateGroupCalendarAccess(calendar, memberId, groupId);
         recipeCalendarRepository.delete(calendar);
     }
 

--- a/src/main/java/com/shortkki/api/calendar/service/RecipeCalendarValidationService.java
+++ b/src/main/java/com/shortkki/api/calendar/service/RecipeCalendarValidationService.java
@@ -1,9 +1,11 @@
 package com.shortkki.api.calendar.service;
 
 import com.shortkki.api.calendar.entity.RecipeCalendar;
+import com.shortkki.api.group.application.service.GroupMemberValidationService;
 import com.shortkki.api.member.entity.Member;
 import com.shortkki.global.error.ErrorCode;
 import com.shortkki.global.error.exception.AccessDeniedException;
+import com.shortkki.global.error.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,14 +15,28 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class RecipeCalendarValidationService {
 
-    private final RecipeCalendarQueryService recipeCalendarQueryService;
+    private final GroupMemberValidationService groupMemberValidationService;
 
-    public void validateRecipeCalendarOwner(long calendarId, long memberId) {
-        RecipeCalendar calendar = recipeCalendarQueryService.findRecipeCalendar(calendarId);
+    public void validatePersonalCalendarOwner(RecipeCalendar calendar, long memberId) {
+        if (calendar.getGroup() != null) {
+            throw new BadRequestException("개인 캘린더가 아닙니다.");
+        }
+
         Member owner = calendar.getMember();
-
-        if (!owner.getId().equals(memberId)) {
+        if (owner == null || !owner.getId().equals(memberId)) {
             throw new AccessDeniedException(ErrorCode.ACCESS_DENIED);
         }
+    }
+
+    public void validateGroupCalendarAccess(RecipeCalendar calendar, long memberId, long groupId) {
+        if (calendar.getGroup() == null) {
+            throw new BadRequestException("그룹 캘린더가 아닙니다.");
+        }
+
+        if (!calendar.getGroup().getId().equals(groupId)) {
+            throw new BadRequestException("해당 그룹의 캘린더가 아닙니다.");
+        }
+
+        groupMemberValidationService.validateGroupMember(memberId, groupId);
     }
 }

--- a/src/main/java/com/shortkki/api/group/application/service/GroupService.java
+++ b/src/main/java/com/shortkki/api/group/application/service/GroupService.java
@@ -1,6 +1,7 @@
 package com.shortkki.api.group.application.service;
 
 
+import com.shortkki.api.calendar.repository.RecipeCalendarRepository;
 import com.shortkki.api.feed.repository.FeedRepository;
 import com.shortkki.api.group.dto.request.CreateGroupRequest;
 import com.shortkki.api.group.dto.request.UpdateGroupRequest;
@@ -43,6 +44,7 @@ public class GroupService {
     private final InviteLinkRepository inviteLinkRepository;
     private final FeedRepository feedRepository;
     private final ShoppingListRepository shoppingListRepository;
+    private final RecipeCalendarRepository recipeCalendarRepository;
   
     @Transactional
     public GroupResponse createGroup(Long memberId, CreateGroupRequest request) {
@@ -78,6 +80,7 @@ public class GroupService {
         validateGroupMemberAdmin(groupMember);
         feedRepository.deleteAllByGroup(group);
         shoppingListRepository.deleteAllByGroup(group);
+        recipeCalendarRepository.deleteAllByGroup(group);
         inviteLinkRepository.deleteAllByGroup(group);
         groupMemberRepository.deleteAllByGroup(group);
         groupRepository.delete(group);

--- a/src/main/java/com/shortkki/api/shopping_list/dto/request/ShoppingListItemRequest.java
+++ b/src/main/java/com/shortkki/api/shopping_list/dto/request/ShoppingListItemRequest.java
@@ -1,6 +1,9 @@
 package com.shortkki.api.shopping_list.dto.request;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record ShoppingListItemRequest(
-        Long recipeIngredientId
+        @NotBlank(message = "재료 이름은 필수입니다.")
+        String name
 ) {
 }

--- a/src/main/java/com/shortkki/api/shopping_list/repository/ShoppingListRepository.java
+++ b/src/main/java/com/shortkki/api/shopping_list/repository/ShoppingListRepository.java
@@ -17,6 +17,9 @@ public interface ShoppingListRepository extends JpaRepository<ShoppingList, Long
     @Query("SELECT sl.ingredient.id FROM ShoppingList sl WHERE sl.group.id = :groupId")
     Set<Long> findIngredientIdsByGroupId(@Param("groupId") Long groupId);
 
+    @Query("SELECT sl.name FROM ShoppingList sl WHERE sl.group.id = :groupId")
+    Set<String> findNamesByGroupId(@Param("groupId") Long groupId);
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("DELETE FROM ShoppingList sl WHERE sl.group = :group")
     void deleteAllByGroup(@Param("group") Group group);

--- a/src/main/java/com/shortkki/api/shopping_list/service/ShoppingListService.java
+++ b/src/main/java/com/shortkki/api/shopping_list/service/ShoppingListService.java
@@ -2,17 +2,12 @@ package com.shortkki.api.shopping_list.service;
 
 import com.shortkki.api.group.application.service.GroupMemberValidationService;
 import com.shortkki.api.group.entity.Group;
-import com.shortkki.api.group.repository.GroupMemberRepository;
 import com.shortkki.api.group.repository.GroupRepository;
-import com.shortkki.api.ingredient.entity.Ingredient;
-import com.shortkki.api.recipe.entity.RecipeIngredient;
-import com.shortkki.api.recipe.repository.RecipeIngredientRepository;
 import com.shortkki.api.shopping_list.dto.request.ShoppingListItemRequest;
 import com.shortkki.api.shopping_list.dto.response.ShoppingListResponse;
 import com.shortkki.api.shopping_list.entity.ShoppingList;
 import com.shortkki.api.shopping_list.repository.ShoppingListRepository;
 import com.shortkki.global.error.ErrorCode;
-import com.shortkki.global.error.exception.AccessDeniedException;
 import com.shortkki.global.error.exception.BadRequestException;
 import com.shortkki.global.error.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +26,6 @@ public class ShoppingListService {
 
     private final ShoppingListRepository shoppingListRepository;
     private final GroupRepository groupRepository;
-    private final RecipeIngredientRepository recipeIngredientRepository;
 
     public List<ShoppingListResponse> getShoppingList(Long memberId, Long groupId) {
         Group group = findGroupById(groupId);
@@ -46,17 +40,11 @@ public class ShoppingListService {
             List<ShoppingListItemRequest> items) {
         Group group = findGroupById(groupId);
         groupMemberValidationService.validateGroupMember(memberId, group.getId());
-        List<Long> recipeIngredientIds = items.stream()
-                .map(ShoppingListItemRequest::recipeIngredientId)
-                .toList();
-        List<RecipeIngredient> recipeIngredients = recipeIngredientRepository
-                .findAllByIdsWithIngredient(recipeIngredientIds);
-        Set<Long> existingIngredientIds = shoppingListRepository
-                .findIngredientIdsByGroupId(groupId);
-        List<ShoppingList> shoppingLists = recipeIngredients.stream()
-                .map(RecipeIngredient::getIngredient)
-                .filter(ingredient -> isNewIngredient(existingIngredientIds, ingredient))
-                .map(ingredient -> ShoppingList.create(ingredient.getName(), ingredient, group))
+        Set<String> existingNames = shoppingListRepository.findNamesByGroupId(groupId);
+        List<ShoppingList> shoppingLists = items.stream()
+                .map(ShoppingListItemRequest::name)
+                .filter(name -> !existingNames.contains(name))
+                .map(name -> ShoppingList.create(name, null, group))
                 .toList();
         shoppingListRepository.saveAll(shoppingLists);
     }
@@ -68,10 +56,6 @@ public class ShoppingListService {
         ShoppingList shoppingList = findShoppingListById(shoppingListId);
         validateShoppingListInGroup(shoppingList, groupId);
         shoppingListRepository.delete(shoppingList);
-    }
-
-    private boolean isNewIngredient(Set<Long> existingIds, Ingredient ingredient) {
-        return !existingIds.contains(ingredient.getId());
     }
 
     private Group findGroupById(Long groupId) {


### PR DESCRIPTION
## 🔥 변경 사항
- 그룹 삭제 시 식단표 데이터 삭제 후 그룹 삭제
- 장볼거리 추가 시 재료 이름으로 추가


<br>

## 🧩 관련 이슈
- related to #41

<br>

## 🛠 작업 내용
- [ ] 그룹 삭제 시 식단표 데이터 삭제 후 그룹 삭제
- [ ] 장볼거리 추가 시 재료 이름으로 추가

<br>

## 📸 스크린샷 / 결과 (선택)
*UI 변경, API 응답 결과 등 첨부*

(내용)

<br>

## ⚠️ 참고 사항 (선택)
- 리뷰 참고 사항
- 중점 확인 사항
- 배포 영향 여부

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 그룹 캘린더 항목을 개별 삭제할 수 있는 그룹용 삭제 API 추가

* **Bug Fixes**
  * 그룹 삭제 시 관련 캘린더 항목을 함께 제거하도록 자동 정리 처리 추가

* **Improvements**
  * 개인/그룹 캘린더 접근권한 검증 로직 정교화
  * 장보기 항목 요청에 이름 필수 검증 추가 및 이름 기반 중복 검사로 생성 흐름 단순화
  * 그룹 범위에서 항목 이름 조회 지원 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->