### PR TITLE
feat : nGrinder 설정 및 테스트 api 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -319,3 +319,7 @@ gradle-app.setting
 
 ### secret
 **-secret.properties
+
+# nGrinder Data Volumes
+ngrinder-controller/
+ngrinder-agent/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,26 @@ services:
     depends_on:
       - elasticsearch
 
+  controller:
+    image: ngrinder/controller
+    restart: always
+    ports:
+      - "80:80"    # 웹 UI 포트
+      - "16001:16001"
+      - "12000-12009:12000-12009"
+    volumes:
+      - ./ngrinder-controller:/opt/ngrinder-controller
+
+  agent:
+    image: ngrinder/agent
+    restart: always
+    links:
+      - controller
+    environment:
+      - CONTROLLER_ADDR=controller:16001
+    volumes:
+      - ./ngrinder-agent:/opt/ngrinder-agent
+
 volumes:
   mysql-data:
   es-data:

--- a/src/main/java/com/shortkki/api/health/HealthController.java
+++ b/src/main/java/com/shortkki/api/health/HealthController.java
@@ -1,0 +1,17 @@
+package com.shortkki.api.health;
+
+import com.shortkki.global.response.BaseResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/health")
+public class HealthController {
+
+    @GetMapping
+    public ResponseEntity<BaseResponse<Void>> health() {
+        return ResponseEntity.ok(BaseResponse.success());
+    }
+}

--- a/src/main/java/com/shortkki/global/config/SecurityConfig.java
+++ b/src/main/java/com/shortkki/global/config/SecurityConfig.java
@@ -36,6 +36,8 @@ public class SecurityConfig {
             "/api/dev/tokens",
             // group
             "/api/v1/groups/invite/**",
+            // health
+            "/api/v1/health",
             // swagger
             "/swagger-ui/**",
             "/swagger-ui.html",

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -5,14 +5,14 @@ spring:
     import: classpath:application-secret.properties
 
   datasource:
-    url: jdbc:mysql://localhost:3306/short_kki?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    url: jdbc:mysql://localhost:3306/short_kki_tmp?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     driver-class-name: com.mysql.cj.jdbc.Driver
-    username: root
-    password: root
+    username: short_kki_admin
+    password: 1234
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     open-in-view: false
     properties:
       hibernate:
@@ -54,19 +54,15 @@ logging:
 oauth2:
   provider:
     google-ios:
-      client-id: local-google-ios-client-id
-      redirect-uri: com.googleusercontent.apps.local://
+      client-id: ${GOOGLE_IOS_CLIENT_ID}
+      redirect-uri: ${GOOGLE_IOS_REDIRECT_URI}
     google-android:
-      client-id: local-google-android-client-id
-      redirect-uri: shortkki://oauth/google
-    kakao:
-      client-id: local-kakao-client-id
-      client-secret: local-kakao-client-secret
-      redirect-uri: http://localhost:3000/oauth/callback/kakao
+      client-id: ${GOOGLE_ANDROID_CLIENT_ID}
+      redirect-uri: ${GOOGLE_ANDROID_REDIRECT_URI}
     naver:
-      client-id: local-naver-client-id
-      client-secret: local-naver-client-secret
-      redirect-uri: http://localhost:3000/oauth/callback/naver
+      client-id: ${NAVER_CLIENT_ID}
+      client-secret: ${NAVER_CLIENT_SECRET}
+      redirect-uri: ${NAVER_REDIRECT_URI}
 
 aws:
   service:

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -5,14 +5,14 @@ spring:
     import: classpath:application-secret.properties
 
   datasource:
-    url: jdbc:mysql://localhost:3306/short_kki_tmp?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    url: jdbc:mysql://localhost:3306/short_kki?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     driver-class-name: com.mysql.cj.jdbc.Driver
-    username: short_kki_admin
-    password: 1234
+    username: root
+    password: root
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     open-in-view: false
     properties:
       hibernate:

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -54,15 +54,15 @@ logging:
 oauth2:
   provider:
     google-ios:
-      client-id: ${GOOGLE_IOS_CLIENT_ID}
-      redirect-uri: ${GOOGLE_IOS_REDIRECT_URI}
+      client-id: local-google-ios-client-id
+      redirect-uri: com.googleusercontent.apps.local://
     google-android:
-      client-id: ${GOOGLE_ANDROID_CLIENT_ID}
-      redirect-uri: ${GOOGLE_ANDROID_REDIRECT_URI}
+      client-id: local-google-android-client-id
+      redirect-uri: shortkki://oauth/google
     naver:
-      client-id: ${NAVER_CLIENT_ID}
-      client-secret: ${NAVER_CLIENT_SECRET}
-      redirect-uri: ${NAVER_REDIRECT_URI}
+      client-id: local-naver-client-id
+      client-secret: local-naver-client-secret
+      redirect-uri: http://localhost:3000/oauth/callback/naver
 
 aws:
   service:


### PR DESCRIPTION
## 🔥 변경 사항
부하, 성능 테스트를 위한 nGrinder docker 설정 및 테스트용 헬스체크 api 추가

<br>

## 🧩 관련 이슈
- related to #59

<br>

## 🛠 작업 내용 
- [ ] nGrinder agent, controller docker compose 설정

<br>

## 📸 스크린샷 / 결과 (선택)
*UI 변경, API 응답 결과 등 첨부*

(내용)

<br>

## ⚠️ 참고 사항 (선택)
- 리뷰 참고 사항
- 중점 확인 사항
- 배포 영향 여부

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 시스템 상태 확인용 헬스(health) 엔드포인트 추가
  * 해당 헬스 엔드포인트를 인증 없이 접근 가능하도록 허용

* **Chores**
  * 로컬 인프라 구성에 성능테스트용 컨트롤러/에이전트 서비스 추가 (docker-compose)
  * 관련 디렉터리들을 .gitignore에 추가
  * 로컬 설정에서 카카오 OAuth2 제공자 설정 제거
<!-- end of auto-generated comment: release notes by coderabbit.ai -->