### PR TITLE
feat: 컨텐츠 피드백 API 구현 (#62)

### DIFF
--- a/src/main/java/com/shortkki/api/contentFeedback/controller/ContentFeedbackController.java
+++ b/src/main/java/com/shortkki/api/contentFeedback/controller/ContentFeedbackController.java
@@ -1,0 +1,29 @@
+package com.shortkki.api.contentFeedback.controller;
+
+import com.shortkki.api.contentFeedback.dto.request.CreateContentFeedbackRequest;
+import com.shortkki.api.contentFeedback.service.ContentFeedbackService;
+import com.shortkki.global.auth.dto.LoginMember;
+import com.shortkki.global.response.BaseResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/feedback")
+@RequiredArgsConstructor
+public class ContentFeedbackController {
+
+    private final ContentFeedbackService contentFeedbackService;
+
+    @PostMapping
+    public ResponseEntity<BaseResponse<Void>> createContentFeedback(
+            @AuthenticationPrincipal LoginMember loginMember,
+            @Valid @RequestBody CreateContentFeedbackRequest request
+    ) {
+        contentFeedbackService.createFeedback(loginMember.getId(), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(BaseResponse.success());
+    }
+}

--- a/src/main/java/com/shortkki/api/contentFeedback/dto/request/CreateContentFeedbackRequest.java
+++ b/src/main/java/com/shortkki/api/contentFeedback/dto/request/CreateContentFeedbackRequest.java
@@ -1,0 +1,21 @@
+package com.shortkki.api.contentFeedback.dto.request;
+
+import com.shortkki.api.contentFeedback.entity.FeedbackTargetType;
+import com.shortkki.api.contentFeedback.entity.FeedbackType;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CreateContentFeedbackRequest(
+        @NotNull(message = "신고 대상 유형은 필수입니다.")
+        FeedbackTargetType targetType,
+
+        @NotNull(message = "신고 대상 ID는 필수입니다.")
+        Long targetId,
+
+        @NotNull(message = "신고 유형은 필수입니다.")
+        FeedbackType feedbackType,
+
+        @Size(max = 500, message = "상세 내용은 500자 이내여야 합니다.")
+        String description
+) {
+}

--- a/src/main/java/com/shortkki/api/contentFeedback/dto/response/ContentFeedbackResponse.java
+++ b/src/main/java/com/shortkki/api/contentFeedback/dto/response/ContentFeedbackResponse.java
@@ -1,0 +1,34 @@
+package com.shortkki.api.contentFeedback.dto.response;
+
+import com.shortkki.api.contentFeedback.entity.ContentFeedback;
+import com.shortkki.api.contentFeedback.entity.FeedbackTargetType;
+import com.shortkki.api.contentFeedback.entity.FeedbackType;
+
+import java.time.LocalDateTime;
+
+public record ContentFeedbackResponse(
+        Long id,
+        Long memberId,
+        String memberName,
+        FeedbackTargetType targetType,
+        Long targetId,
+        FeedbackType feedbackType,
+        String description,
+        boolean resolved,
+        LocalDateTime createdAt
+) {
+
+    public static ContentFeedbackResponse from(ContentFeedback feedback) {
+        return new ContentFeedbackResponse(
+                feedback.getId(),
+                feedback.getMember().getId(),
+                feedback.getMember().getName(),
+                feedback.getTargetType(),
+                feedback.getTargetId(),
+                feedback.getFeedbackType(),
+                feedback.getDescription(),
+                feedback.isResolved(),
+                feedback.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/shortkki/api/contentFeedback/entity/ContentFeedback.java
+++ b/src/main/java/com/shortkki/api/contentFeedback/entity/ContentFeedback.java
@@ -1,0 +1,57 @@
+package com.shortkki.api.contentFeedback.entity;
+
+import com.shortkki.api.member.entity.Member;
+import com.shortkki.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "content_feedback")
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@Getter
+public class ContentFeedback extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FeedbackTargetType targetType;
+
+    @Column(nullable = false)
+    private Long targetId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FeedbackType feedbackType;
+
+    @Column(length = 550)
+    private String description;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private boolean resolved = false;
+
+    public static ContentFeedback create(
+            Member member, FeedbackTargetType targetType, Long targetId, FeedbackType feedbackType, String description
+    ) {
+        return ContentFeedback.builder()
+                .member(member)
+                .targetType(targetType)
+                .targetId(targetId)
+                .feedbackType(feedbackType)
+                .description(description)
+                .build();
+    }
+}

--- a/src/main/java/com/shortkki/api/contentFeedback/entity/FeedbackTargetType.java
+++ b/src/main/java/com/shortkki/api/contentFeedback/entity/FeedbackTargetType.java
@@ -1,0 +1,6 @@
+package com.shortkki.api.contentFeedback.entity;
+
+public enum FeedbackTargetType {
+    RECIPE,
+    FEED
+}

--- a/src/main/java/com/shortkki/api/contentFeedback/entity/FeedbackType.java
+++ b/src/main/java/com/shortkki/api/contentFeedback/entity/FeedbackType.java
@@ -1,0 +1,9 @@
+package com.shortkki.api.contentFeedback.entity;
+
+public enum FeedbackType {
+    INACCURATE,
+    COPYRIGHT_INFRINGEMENT,
+    INAPPROPRIATE_CONTENT,
+    SPAM_AD,
+    OTHER
+}

--- a/src/main/java/com/shortkki/api/contentFeedback/repository/ContentFeedbackRepository.java
+++ b/src/main/java/com/shortkki/api/contentFeedback/repository/ContentFeedbackRepository.java
@@ -1,0 +1,7 @@
+package com.shortkki.api.contentFeedback.repository;
+
+import com.shortkki.api.contentFeedback.entity.ContentFeedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContentFeedbackRepository extends JpaRepository<ContentFeedback, Long> {
+}

--- a/src/main/java/com/shortkki/api/contentFeedback/service/ContentFeedbackService.java
+++ b/src/main/java/com/shortkki/api/contentFeedback/service/ContentFeedbackService.java
@@ -1,0 +1,62 @@
+package com.shortkki.api.contentFeedback.service;
+
+import com.shortkki.api.contentFeedback.dto.request.CreateContentFeedbackRequest;
+import com.shortkki.api.contentFeedback.entity.ContentFeedback;
+import com.shortkki.api.contentFeedback.entity.FeedbackTargetType;
+import com.shortkki.api.contentFeedback.repository.ContentFeedbackRepository;
+import com.shortkki.api.feed.repository.FeedRepository;
+import com.shortkki.api.member.entity.Member;
+import com.shortkki.api.member.repository.MemberRepository;
+import com.shortkki.api.recipe.repository.RecipeRepository;
+import com.shortkki.global.error.ErrorCode;
+import com.shortkki.global.error.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContentFeedbackService {
+
+    private final ContentFeedbackRepository contentFeedbackRepository;
+    private final MemberRepository memberRepository;
+    private final RecipeRepository recipeRepository;
+    private final FeedRepository feedRepository;
+
+    @Transactional
+    public void createFeedback(Long memberId, CreateContentFeedbackRequest request) {
+        Member member = findMemberById(memberId);
+        validateTargetExists(request.targetType(), request.targetId());
+
+        ContentFeedback feedback = ContentFeedback.create(
+                member,
+                request.targetType(),
+                request.targetId(),
+                request.feedbackType(),
+                request.description()
+        );
+
+        contentFeedbackRepository.save(feedback);
+    }
+
+    private void validateTargetExists(FeedbackTargetType targetType, Long targetId) {
+        switch (targetType) {
+            case RECIPE -> {
+                if (!recipeRepository.existsById(targetId)) {
+                    throw new NotFoundException(ErrorCode.RECIPE_NOT_FOUND);
+                }
+            }
+            case FEED -> {
+                if (!feedRepository.existsById(targetId)) {
+                    throw new NotFoundException(ErrorCode.NOT_FOUND_ERROR);
+                }
+            }
+        }
+    }
+
+    private Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## 🔥 변경 사항                                                                                                                                                          
                                                                                                                                                                           
  레시피, 피드 등 콘텐츠에 대한 사용자 신고(피드백) 기능을 추가했습니다.                                                                                                   
  신고 대상 유형과 사유를 분류하여 저장하고, 추후 관리자가 처리 상태를 관리할 수 있도록 구성했습니다.                                                                      
                                                                                                                                                                           
  <br>                                                                                                                                                                     

  ## 🧩 관련 이슈                                                                                                                                                          
  - related to #62

  <br>

  ## 🛠 작업 상세

  ### 패키지 구조

  `contentFeedback` 도메인 모듈을 신규 생성했습니다.

  ```
  com.shortkki.api.contentFeedback
  ├── controller/
  │   └── ContentFeedbackController
  ├── dto/
  │   ├── request/  CreateContentFeedbackRequest
  │   └── response/ ContentFeedbackResponse
  ├── entity/
  │   ├── ContentFeedback
  │   ├── FeedbackTargetType
  │   └── FeedbackType
  ├── repository/
  │   └── ContentFeedbackRepository
  └── service/
      └── ContentFeedbackService
  ```

  ### API

  `POST /api/v1/feedback` (인증 필요, 201 Created)

  ### 엔티티 설계

  `ContentFeedback`은 특정 도메인 엔티티와 직접 연관관계를 맺지 않고, `targetType` + `targetId` 조합으로 대상을 참조합니다. 신고 대상이 레시피, 피드 외에도 확장될 수
  있으므로 다형적 참조 방식을 사용했습니다.

  | 필드 | 설명 |
  |------|------|
  | `member` | 신고자 (ManyToOne) |
  | `targetType` | 신고 대상 유형 (`RECIPE`, `FEED`) |
  | `targetId` | 신고 대상 ID |
  | `feedbackType` | 신고 사유 |
  | `description` | 상세 설명 (최대 500자, 선택) |
  | `resolved` | 처리 완료 여부 (기본값 `false`) |

  ### 신고 사유 (`FeedbackType`)

  | 값 | 의미 |
  |----|------|
  | `INACCURATE` | 부정확한 정보 |
  | `COPYRIGHT_INFRINGEMENT` | 저작권 침해 |
  | `INAPPROPRIATE_CONTENT` | 부적절한 콘텐츠 |
  | `SPAM_AD` | 스팸/광고 |
  | `OTHER` | 기타 |

  ### 처리 흐름

  1. `targetType`에 따라 해당 콘텐츠(레시피 또는 피드)의 존재 여부를 검증합니다.
  2. 존재하지 않으면 `NotFoundException`이 발생합니다.
  3. 검증 통과 시 `ContentFeedback` 엔티티를 생성하여 저장합니다.

  <br>

  ## ⚠️ 참고 사항
  - `content_feedback` 테이블의 DB 마이그레이션 스크립트가 이 PR에 포함되어 있지 않습니다. 별도 추가가 필요합니다.
  - `ContentFeedbackResponse`와 `resolved` 필드는 관리자 조회/처리 API를 위해 준비해두었습니다. 해당 API는 이번 PR 범위에 포함되지 않습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 콘텐츠 피드백 제출 기능 추가
  * 레시피 및 피드에 대한 문제 신고 가능
  * 5가지 피드백 카테고리 지원: 부정확함, 저작권 침해, 부적절한 콘텐츠, 스팸·광고, 기타
  * 최대 500자의 상세 설명 추가 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->