### PR TITLE
feat: refresh 토큰으로 새로운 accessToken 발급

### DIFF
--- a/src/main/java/com/shortkki/api/auth/application/service/AuthService.java
+++ b/src/main/java/com/shortkki/api/auth/application/service/AuthService.java
@@ -327,10 +327,17 @@ public class AuthService {
     }
 
     @Transactional(readOnly = true)
-    public RefreshTokenResponse refreshAccessToken(String refreshToken) {
+    public RefreshTokenResponse refreshAccessToken(String accessToken, String refreshToken) {
+        validateAccessTokenForRefresh(accessToken);
         validateRefreshToken(refreshToken);
 
+        Long accessTokenMemberId = jwtTokenProvider.getMemberIdFromToken(accessToken);
         Long memberId = jwtTokenProvider.getMemberIdFromToken(refreshToken);
+
+        if (!Objects.equals(accessTokenMemberId, memberId)) {
+            throw new BadRequestException(ErrorCode.INVALID_TOKEN);
+        }
+
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
 
@@ -339,8 +346,23 @@ public class AuthService {
                 member.getEmail(),
                 member.getRole()
         );
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(member.getId());
 
-        return new RefreshTokenResponse(newAccessToken);
+        return new RefreshTokenResponse(newAccessToken, newRefreshToken);
+    }
+
+    private void validateAccessTokenForRefresh(String accessToken) {
+        if (accessToken == null || accessToken.isBlank()) {
+            throw new BadRequestException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        if (!jwtTokenProvider.isAccessToken(accessToken)) {
+            throw new BadRequestException(ErrorCode.INVALID_TOKEN);
+        }
+
+        if (jwtTokenProvider.isTokenValid(accessToken)) {
+            throw new BadRequestException("아직 유효한 accessToken은 재발급할 수 없습니다.");
+        }
     }
 
     private void validateRefreshToken(String refreshToken) {

--- a/src/main/java/com/shortkki/api/auth/application/service/AuthService.java
+++ b/src/main/java/com/shortkki/api/auth/application/service/AuthService.java
@@ -2,14 +2,17 @@ package com.shortkki.api.auth.application.service;
 
 import com.shortkki.api.auth.dto.LoginRequest;
 import com.shortkki.api.auth.dto.LoginResponse;
+import com.shortkki.api.auth.dto.RefreshTokenResponse;
 import com.shortkki.global.entity.Platform;
 import com.shortkki.api.member.entity.Member;
 import com.shortkki.api.member.entity.OAuthProvider;
 import com.shortkki.api.member.repository.MemberRepository;
 import com.shortkki.global.auth.jwt.JwtTokenProvider;
 import com.shortkki.global.config.OAuth2Properties;
+import com.shortkki.global.error.exception.BadRequestException;
 import com.shortkki.global.error.exception.BusinessException;
 import com.shortkki.global.error.ErrorCode;
+import com.shortkki.global.error.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -92,7 +95,8 @@ public class AuthService {
         OAuth2Properties.Provider providerConfig = oAuth2Properties.getProvider(configKey);
 
         // accessToken으로 바로 사용자 정보 조회
-        Map<String, Object> userInfo = getUserInfo(request.getAccessToken(), providerConfig, provider);
+        Map<String, Object> userInfo = getUserInfo(request.getAccessToken(), providerConfig,
+                provider);
 
         String oauthId = extractOAuthId(userInfo, provider);
         String email = extractEmail(userInfo, provider);
@@ -123,7 +127,8 @@ public class AuthService {
             throw new BusinessException(ErrorCode.ID_TOKEN_OR_CODE_REQUIRED);
         }
 
-        log.info("OAuth login request - provider: {}, platform: {}, hasCode: {}, hasCodeVerifier: {}",
+        log.info(
+                "OAuth login request - provider: {}, platform: {}, hasCode: {}, hasCodeVerifier: {}",
                 provider,
                 request.getPlatform(),
                 request.hasCode(),
@@ -319,6 +324,36 @@ public class AuthService {
             OAuthProvider provider) {
         Member newMember = Member.create(email, name, oauthId, provider, null);
         return memberRepository.save(newMember);
+    }
+
+    @Transactional(readOnly = true)
+    public RefreshTokenResponse refreshAccessToken(String refreshToken) {
+        validateRefreshToken(refreshToken);
+
+        Long memberId = jwtTokenProvider.getMemberIdFromToken(refreshToken);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+
+        String newAccessToken = jwtTokenProvider.createAccessToken(
+                member.getId(),
+                member.getEmail(),
+                member.getRole()
+        );
+
+        return new RefreshTokenResponse(newAccessToken);
+    }
+
+    private void validateRefreshToken(String refreshToken) {
+
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new BadRequestException(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
+        jwtTokenProvider.validateToken(refreshToken);
+
+        if (!jwtTokenProvider.isRefreshToken(refreshToken)) {
+            throw new BadRequestException(ErrorCode.INVALID_TOKEN);
+        }
     }
 
 }

--- a/src/main/java/com/shortkki/api/auth/controller/AuthController.java
+++ b/src/main/java/com/shortkki/api/auth/controller/AuthController.java
@@ -1,8 +1,11 @@
 package com.shortkki.api.auth.controller;
 
+import com.shortkki.api.auth.application.service.AuthService;
 import com.shortkki.api.auth.application.usecase.RegisterUserUseCase;
 import com.shortkki.api.auth.dto.LoginRequest;
 import com.shortkki.api.auth.dto.LoginResponse;
+import com.shortkki.api.auth.dto.RefreshTokenRequest;
+import com.shortkki.api.auth.dto.RefreshTokenResponse;
 import com.shortkki.api.member.entity.OAuthProvider;
 import com.shortkki.global.response.BaseResponse;
 import jakarta.validation.Valid;
@@ -20,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final RegisterUserUseCase registerUserUseCase;
+    private final AuthService authService;
 
     @PostMapping("/{provider}")
     public ResponseEntity<BaseResponse<LoginResponse>> login(
@@ -28,4 +32,15 @@ public class AuthController {
         LoginResponse response = registerUserUseCase.execute(provider, request);
         return ResponseEntity.ok(BaseResponse.success("로그인에 성공했습니다.", response));
     }
+
+    // TODO : RT 로테이션 도입 및 레디스
+    @PostMapping("/refresh")
+    public ResponseEntity<BaseResponse<RefreshTokenResponse>> refresh(
+            @Valid @RequestBody RefreshTokenRequest request
+    ) {
+        RefreshTokenResponse response = authService.refreshAccessToken(request.refreshToken());
+        return ResponseEntity.ok(BaseResponse.success("토큰 재발급 성공", response));
+    }
+
+
 }

--- a/src/main/java/com/shortkki/api/auth/controller/AuthController.java
+++ b/src/main/java/com/shortkki/api/auth/controller/AuthController.java
@@ -38,7 +38,10 @@ public class AuthController {
     public ResponseEntity<BaseResponse<RefreshTokenResponse>> refresh(
             @Valid @RequestBody RefreshTokenRequest request
     ) {
-        RefreshTokenResponse response = authService.refreshAccessToken(request.refreshToken());
+        RefreshTokenResponse response = authService.refreshAccessToken(
+                request.accessToken(),
+                request.refreshToken()
+        );
         return ResponseEntity.ok(BaseResponse.success("토큰 재발급 성공", response));
     }
 

--- a/src/main/java/com/shortkki/api/auth/dto/RefreshTokenRequest.java
+++ b/src/main/java/com/shortkki/api/auth/dto/RefreshTokenRequest.java
@@ -1,0 +1,10 @@
+package com.shortkki.api.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshTokenRequest(
+        @NotBlank(message = "refreshToken은 비어있을 수 없습니다.")
+        String refreshToken
+) {
+
+}

--- a/src/main/java/com/shortkki/api/auth/dto/RefreshTokenRequest.java
+++ b/src/main/java/com/shortkki/api/auth/dto/RefreshTokenRequest.java
@@ -3,6 +3,8 @@ package com.shortkki.api.auth.dto;
 import jakarta.validation.constraints.NotBlank;
 
 public record RefreshTokenRequest(
+        @NotBlank(message = "accessToken은 비어있을 수 없습니다.")
+        String accessToken,
         @NotBlank(message = "refreshToken은 비어있을 수 없습니다.")
         String refreshToken
 ) {

--- a/src/main/java/com/shortkki/api/auth/dto/RefreshTokenResponse.java
+++ b/src/main/java/com/shortkki/api/auth/dto/RefreshTokenResponse.java
@@ -1,0 +1,8 @@
+package com.shortkki.api.auth.dto;
+
+
+public record RefreshTokenResponse(
+        String accessToken
+) {
+
+}

--- a/src/main/java/com/shortkki/api/auth/dto/RefreshTokenResponse.java
+++ b/src/main/java/com/shortkki/api/auth/dto/RefreshTokenResponse.java
@@ -2,7 +2,8 @@ package com.shortkki.api.auth.dto;
 
 
 public record RefreshTokenResponse(
-        String accessToken
+        String accessToken,
+        String refreshToken
 ) {
 
 }

--- a/src/main/java/com/shortkki/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/shortkki/global/auth/jwt/JwtTokenProvider.java
@@ -129,4 +129,10 @@ public class JwtTokenProvider {
         Claims claims = parseClaims(token);
         return Long.parseLong(claims.getSubject());
     }
+
+    public boolean isRefreshToken(String token) {
+        Claims claims = parseClaims(token);
+        String type = claims.get("type", String.class);
+        return "refresh".equals(type);
+    }
 }

--- a/src/main/java/com/shortkki/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/shortkki/global/auth/jwt/JwtTokenProvider.java
@@ -122,6 +122,8 @@ public class JwtTokenProvider {
                     .getPayload();
         } catch (ExpiredJwtException e) {
             return e.getClaims();
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.INVALID_TOKEN);
         }
     }
 
@@ -134,5 +136,11 @@ public class JwtTokenProvider {
         Claims claims = parseClaims(token);
         String type = claims.get("type", String.class);
         return "refresh".equals(type);
+    }
+
+    public boolean isAccessToken(String token) {
+        Claims claims = parseClaims(token);
+        String type = claims.get("type", String.class);
+        return "access".equals(type);
     }
 }


### PR DESCRIPTION
-

## 🔥 변경 사항
refresh 토크으로 새로운 accessToken 발급할 수  있다.
refresh rotation은 추후 redish 와 함께 도입 예정

(내용)

<br>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* **토큰 갱신 기능**: 새로운 토큰 갱신 엔드포인트가 추가되어 사용자가 만료된 액세스 토큰을 손쉽게 갱신할 수 있습니다.
* **강화된 검증**: 갱신 토큰 요청 시 공백 확인, 토큰 유효성 검증, 토큰 타입 확인 등 보안 검증이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->