### PR TITLE
env: dev 환경 로깅 설정 및 로그 볼륨 마운트 추가 (#76)

### DIFF
--- a/scripts/deploy-dev.sh
+++ b/scripts/deploy-dev.sh
@@ -25,6 +25,7 @@ docker run -d \
   -p 80:8080 \
   -v ~/shortkki/env:/app/env \
   -v ~/shortkki/secrets:/app/secrets \
+  -v ~/shortkki/logs:/app/logs \
   -e SPRING_PROFILES_ACTIVE=dev \
   "${IMAGE}:${TAG}"
 
@@ -65,6 +66,7 @@ docker run -d \
   -p 80:8080 \
   -v ~/shortkki/env:/app/env \
   -v ~/shortkki/secrets:/app/secrets \
+  -v ~/shortkki/logs:/app/logs \
   -e SPRING_PROFILES_ACTIVE=dev \
   "${PREV_IMAGE}"
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <property name="LOG_PATTERN"
+              value="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{40} - %msg%n"/>
+
+    <!-- ==================== 공통: 콘솔 Appender (모든 프로필) ==================== -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+    <!-- ==================== dev: 파일 Appender 추가 (일별 롤링, 7일 보관) ==================== -->
+    <springProfile name="dev">
+        <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>/app/logs/application.log</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                <fileNamePattern>/app/logs/application.%d{yyyy-MM-dd}.log</fileNamePattern>
+                <maxHistory>7</maxHistory>
+                <totalSizeCap>500MB</totalSizeCap>
+            </rollingPolicy>
+            <encoder>
+                <pattern>${LOG_PATTERN}</pattern>
+                <charset>UTF-8</charset>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE"/>
+        </root>
+    </springProfile>
+
+</configuration>


### PR DESCRIPTION
## 🔥 변경 사항

dev 환경에서 애플리케이션 로그를 파일로 남기도록 Logback 설정을 추가했습니다.
Docker 볼륨 마운트를 통해 호스트에서 로그 파일을 직접 확인할 수 있습니다.

<br>

## 🧩 관련 이슈

- related to #76

<br>

## 🛠 작업 상세

### logback-spring.xml 프로필별 로깅 설정

`logback-spring.xml`을 새로 추가하여 `<springProfile>` 태그 기반으로 프로필별 로깅을 분리했습니다.

| 프로필 | Appender | 설명 |
|--------|----------|------|
| 공통 (기본) | `CONSOLE` | 모든 프로필에서 콘솔 INFO 출력 |
| `dev` | `CONSOLE` + `FILE` | 콘솔 + 파일 출력 |
| 그 외 (`local`, `prod`, `test`) | `CONSOLE` | 공통 root 자동 적용 |

dev 프로필의 `FILE` appender는 `RollingFileAppender`로, 일별 롤링 + 7일 보관 + 총 500MB 상한으로 설정했습니다.

prod 환경에 Loki 등 로그 수집 시스템을 붙일 때는 `<springProfile name="prod">` 블록만 추가하면 됩니다.

### dev 배포 스크립트 볼륨 마운트

`scripts/deploy-dev.sh`의 `docker run` 명령(일반 배포 + 롤백)에 로그 볼륨 마운트를 추가했습니다.

```
-v ~/shortkki/logs:/app/logs
```

호스트의 `~/shortkki/logs/`에서 로그 파일을 직접 확인할 수 있습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **기타 개선**
  * 로그 시스템이 개선되었습니다.
  * 개발 환경에서 일일 자동 로그 파일 로테이션이 지원됩니다.
  * 로그는 콘솔과 파일 형식으로 동시에 저장됩니다.
  * 이전 로그는 최대 7일간 보관되고, 저장소 총 용량은 500MB로 제한됩니다.
  * UTF-8 인코딩으로 안정적인 로그 저장을 보장합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->