### PR TITLE
env: ES 인덱스명 환경별 동적 분리 (#62)

### DIFF
--- a/src/main/java/com/shortkki/api/search/infra/elasticsearch/document/RecipeDocument.java
+++ b/src/main/java/com/shortkki/api/search/infra/elasticsearch/document/RecipeDocument.java
@@ -11,7 +11,7 @@ import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 
-@Document(indexName = "recipes")
+@Document(indexName = "${elasticsearch.index.recipe.name}")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -29,6 +29,12 @@ jwt:
 server:
   shutdown: graceful
 
+elasticsearch:
+  index:
+    recipe:
+      name: recipes-dev
+      settings-path: search/index/recipe-index.json
+
 oauth2:
   provider:
     google-web:

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -62,3 +62,16 @@ public-data:
 springdoc:
   api-docs:
     enabled: false
+
+deep-link:
+  web-domain: ${DEEP_LINK_WEB_DOMAIN}
+  ios:
+    team-id: ${DEEP_LINK_IOS_TEAM_ID}
+    bundle-id: ${DEEP_LINK_IOS_BUNDLE_ID}
+  android:
+    package-name: ${DEEP_LINK_ANDROID_PACKAGE}
+    sha256-cert-fingerprints:
+      - ${DEEP_LINK_ANDROID_SHA256}
+  store:
+    app-store-url: ${DEEP_LINK_APP_STORE_URL}
+    play-store-url: ${DEEP_LINK_PLAY_STORE_URL}

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -29,6 +29,12 @@ jwt:
 server:
   shutdown: graceful
 
+elasticsearch:
+  index:
+    recipe:
+      name: recipes-prod
+      settings-path: search/index/recipe-index.json
+
 oauth2:
   provider:
     google-ios:


### PR DESCRIPTION
## 🔥 변경 사항

dev와 prod가 하나의 Elasticsearch 인스턴스를 공유하고 있어, 환경별로 인덱스를 분리합니다.
기존에는 `RecipeDocument`의 `@Document(indexName)`이 `"recipes"`로 하드코딩되어 있어 Spring Data ES의 모든 연산(save, search, delete)이 단일 인덱스로 향하는 문제가 있었습니다.

<br>

## 🧩 관련 이슈

- related to #62

<br>

## 🛠 작업 상세

### 문제 상황

하나의 ES 인스턴스를 사용하고 있어, 개발 환경과 운영 환경의 레시피 ID가 겹칠 경우 같은 ID로 중복 레시피가 등록될 가능성이 있었습니다.

### 해결 방법

따라서 개발/운영의 ES 인덱스를 분리하여 데이터가 서로 겹치지 않고 영향을 주지 않도록 수정했습니다.

Spring Data Elasticsearch의 `@Document` 어노테이션이 `${}` 프로퍼티 플레이스홀더를 지원하므로, 별도의 Bean 등록 없이 한 줄 변경으로 해결합니다.

```java
// Before
@Document(indexName = "recipes")

// After
@Document(indexName = "${elasticsearch.index.recipe.name}")
```

이 변경으로 `RecipeDocumentRepository`, `ElasticsearchOperations`를 사용하는 모든 어댑터(`ESRecipeSearchAdapter`, `ESRecipeSearchIndexer`)가 자동으로 환경별 인덱스를 사용합니다.

### 환경별 인덱스 설정 추가

`application-dev.yaml`, `application-prod.yaml`에 `elasticsearch.index.recipe` 설정을 추가합니다.

| 환경 | 인덱스명 |
|------|----------|
| dev | `recipes-dev` |
| prod | `recipes-prod` |

`recipe-index.json`은 settings/mappings만 포함하고 인덱스명은 없으므로 환경 간 공유를 유지합니다.

<br>

## ⚠️ 참고 사항

- prod 환경에 최초 배포 시 `recipes-prod` 인덱스가 존재하지 않으므로, SearchAdmin API(`POST /api/admin/search/reindex`)로 인덱스 생성 및 데이터 적재가 필요합니다.
- 기존 `recipes` 인덱스는 더 이상 사용되지 않으므로, 배포 후 수동 삭제하면 됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 검색 서비스의 Elasticsearch 인덱스를 환경별 동적 구성으로 전환하여 개발/프로덕션별 인덱스 설정을 적용하도록 변경했습니다.
* **New Features**
  * 프로덕션 환경에 딥링크(웹 도메인, iOS/Android 식별자 및 스토어 링크) 설정을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->