### PR TITLE
fix: ES @Document indexName SpEL 표현식 수정 및 환경 설정 동기화 (#62)

### DIFF
--- a/scripts/build-push-dev.bat
+++ b/scripts/build-push-dev.bat
@@ -1,0 +1,20 @@
+@echo off
+setlocal
+
+set IMAGE=leechanmi/short-kki-server:latest-dev
+
+echo === Building JAR ===
+call gradlew.bat clean bootJar -x test
+if %errorlevel% neq 0 (
+    echo JAR build failed
+    exit /b 1
+)
+
+echo === Building and pushing Docker image (arm64) ===
+docker buildx build --platform linux/arm64 --push -t %IMAGE% .
+if %errorlevel% neq 0 (
+    echo Docker build/push failed
+    exit /b 1
+)
+
+echo === Done: %IMAGE% ===

--- a/scripts/deploy-dev.sh
+++ b/scripts/deploy-dev.sh
@@ -14,6 +14,10 @@ echo "Previous image: ${PREV_IMAGE:-none}"
 echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$GITHUB_ACTOR" --password-stdin
 docker pull "${IMAGE}:${TAG}"
 
+# 로그 디렉토리 생성 (볼륨 마운트 시 appuser 쓰기 권한 확보)
+mkdir -p ~/shortkki/logs
+chmod 777 ~/shortkki/logs
+
 # 기존 컨테이너 중지
 docker stop shortkki-server || true
 docker rm shortkki-server || true

--- a/scripts/run-dev.sh
+++ b/scripts/run-dev.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+IMAGE="leechanmi/short-kki-server:latest-dev"
+
+echo "=== Pulling image: ${IMAGE} ==="
+docker pull "${IMAGE}"
+
+echo "=== Stopping previous container ==="
+docker stop shortkki-server || true
+docker rm shortkki-server || true
+
+echo "=== Starting container ==="
+docker run -d \
+  --name shortkki-server \
+  --restart unless-stopped \
+  -p 80:8080 \
+  -v ~/shortkki/env:/app/env \
+  -v ~/shortkki/secrets:/app/secrets \
+  -e SPRING_PROFILES_ACTIVE=dev \
+  "${IMAGE}"
+
+echo "=== Waiting for health check ==="
+for i in $(seq 1 30); do
+  if curl -sf http://localhost/actuator/health > /dev/null 2>&1; then
+    echo "Health check passed"
+    docker image prune -f
+    echo "=== Deploy succeeded ==="
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "Health check failed. Logs:"
+docker logs --tail 50 shortkki-server
+exit 1

--- a/src/main/java/com/shortkki/api/search/infra/elasticsearch/document/RecipeDocument.java
+++ b/src/main/java/com/shortkki/api/search/infra/elasticsearch/document/RecipeDocument.java
@@ -11,7 +11,7 @@ import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
 
-@Document(indexName = "${elasticsearch.index.recipe.name}")
+@Document(indexName = "#{@environment.getProperty('elasticsearch.index.recipe.name')}")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -37,16 +37,10 @@ elasticsearch:
 
 oauth2:
   provider:
-    google-ios:
-      client-id: ${GOOGLE_IOS_CLIENT_ID}
-      redirect-uri: ${GOOGLE_IOS_REDIRECT_URI}
-    google-android:
-      client-id: ${GOOGLE_ANDROID_CLIENT_ID}
-      redirect-uri: ${GOOGLE_ANDROID_REDIRECT_URI}
+    google-web:
+      client-id: ${GOOGLE_WEB_CLIENT_ID}
     naver:
-      client-id: ${NAVER_CLIENT_ID}
-      client-secret: ${NAVER_CLIENT_SECRET}
-      redirect-uri: ${NAVER_REDIRECT_URI}
+      user-info-uri: https://openapi.naver.com/v1/nid/me
 
 google:
   credential:


### PR DESCRIPTION
## 🔥 변경 사항

`RecipeDocument`의 `@Document(indexName)` 에서 `${}` 프로퍼티 플레이스홀더가 resolve되지 않아 `${elasticsearch.index.recipe.name}` 이라는 문자열이 그대로 인덱스명으로 사용되는 버그를 수정합니다.
추가로 prod 설정 파일을 dev와 동기화하고, dev 배포 스크립트를 보완합니다.

<br>

## 🧩 관련 이슈

related to #62

<br>

## 🛠 작업 상세

### `@Document` indexName SpEL 수정

Spring Data Elasticsearch의 `@Document` 어노테이션은 `${}` 프로퍼티 플레이스홀더를 지원하지 않습니다. `${}` 문자열이 그대로 인덱스명이 되어, reindex 시 데이터가 `recipes-dev`가 아닌 `${elasticsearch.index.recipe.name}` 인덱스에 저장되는 문제가 있었습니다.

SpEL `#{}` 문법으로 Spring의 `Environment` 빈에서 프로퍼티를 읽도록 수정합니다.

```java
// Before
@Document(indexName = "${elasticsearch.index.recipe.name}")

// After
@Document(indexName = "#{@environment.getProperty('elasticsearch.index.recipe.name')}")
```

### prod 설정 동기화

`application-prod.yaml`을 dev와 동기화합니다.

- OAuth2 provider: 플랫폼별 분기(google-ios, google-android) → `google-web` 단일 설정으로 변경
- Naver: client-id/secret/redirect-uri → `user-info-uri`로 간소화
- `deep-link` 섹션 추가

### dev 배포 스크립트 업데이트

- `deploy-dev.sh`: 로그 디렉토리 생성 및 권한 설정 추가 (볼륨 마운트 시 appuser 쓰기 권한 확보)
- `build-push-dev.bat`: 로컬 Windows 환경에서 arm64 이미지 빌드/푸시 스크립트 추가
- `run-dev.sh`: 수동 배포용 스크립트 추가 (pull → run → health check)

<br>

## ⚠️ 참고 사항

- 배포 후 ES에 잘못 생성된 `${elasticsearch.index.recipe.name}` 인덱스를 수동 삭제해야 합니다.
- prod 최초 배포 시 `POST /api/admin/search/reindex`로 `recipes-prod` 인덱스 생성 및 데이터 적재가 필요합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Chores**
  * 개발 환경 빌드 및 배포 자동화 스크립트 추가
  * 컨테이너 헬스 체크 및 로그 관리 기능 개선

* **Configuration**
  * Google OAuth 인증 제공자 통합
  * Naver OAuth 사용자 정보 엔드포인트 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->