### PR TITLE
fix: ES 검색 페이징 버그 수정 및 파싱 완료 알림 개선 (#62)

### DIFF
--- a/src/main/java/com/shortkki/api/notification/event/NotificationEvent.java
+++ b/src/main/java/com/shortkki/api/notification/event/NotificationEvent.java
@@ -77,11 +77,11 @@ public record NotificationEvent(
         );
     }
 
-    public static NotificationEvent importedRecipeCompleted(Long receiverId, Long recipeId) {
+    public static NotificationEvent importedRecipeCompleted(Long receiverId, Long recipeId, String recipeTitle) {
         return new NotificationEvent(
                 List.of(receiverId),
                 NotificationType.RECIPE_IMPORT_COMPLETED,
-                "외부 레시피 파싱이 완료되어 저장되었어요.",
+                "'" + recipeTitle + "' 레시피가 저장되었어요.",
                 recipeId,
                 toJson(Map.of("recipeId", String.valueOf(recipeId)))
         );

--- a/src/main/java/com/shortkki/api/recipeImport/service/RecipeImportTransactionalService.java
+++ b/src/main/java/com/shortkki/api/recipeImport/service/RecipeImportTransactionalService.java
@@ -60,7 +60,7 @@ public class RecipeImportTransactionalService {
         domainEventPublisher.publish(new RecipeIndexUpsertEvent(recipe.getId()));
         // TODO(#62): Notification 도메인 담당과 앱내 알림 저장/푸시 전송 분리 정책 확정 후 반영
         domainEventPublisher.publish(
-                NotificationEvent.importedRecipeCompleted(member.getId(), recipe.getId()));
+                NotificationEvent.importedRecipeCompleted(member.getId(), recipe.getId(), recipe.getBasicInfo().getTitle()));
         return recipe;
     }
 

--- a/src/main/java/com/shortkki/api/search/infra/elasticsearch/adapter/ESRecipeSearchAdapter.java
+++ b/src/main/java/com/shortkki/api/search/infra/elasticsearch/adapter/ESRecipeSearchAdapter.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -60,11 +61,11 @@ public class ESRecipeSearchAdapter implements RecipeSearchPort {
                 searchWord, tags, ingredients, recipeSource, cuisineTypes, mealTypes, difficulties
         );
 
+        Pageable slicePageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize() + 1);
         NativeQueryBuilder queryBuilder = NativeQuery.builder()
                 .withQuery(applyFunctionScore(bool.build()._toQuery()))
                 .withSort(s -> s.score(sc -> sc.order(SortOrder.Desc)))
-                .withMaxResults(pageable.getPageSize() + 1)
-                .withPageable(pageable);
+                .withPageable(slicePageable);
 
         if (!hasSearchWord) {
             queryBuilder
@@ -87,11 +88,11 @@ public class ESRecipeSearchAdapter implements RecipeSearchPort {
         bool.filter(f -> f.term(t -> t.field("contentStatus").value(ContentStatus.AVAILABLE.name())));
         bool.filter(f -> f.term(t -> t.field("playable").value(true)));
 
+        Pageable slicePageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize() + 1);
         NativeQuery query = NativeQuery.builder()
                 .withQuery(applyCurationFunctionScore(bool.build()._toQuery()))
                 .withSort(s -> s.score(sc -> sc.order(SortOrder.Desc)))
-                .withMaxResults(pageable.getPageSize() + 1)
-                .withPageable(pageable)
+                .withPageable(slicePageable)
                 .build();
 
         return executeSearch(pageable, query);


### PR DESCRIPTION
## 🔥 변경 사항

- ES 검색에서 `withMaxResults`와 `withPageable`이 충돌하여 페이징 시 항상 `hasNext=false`를 반환하던 버그를 수정했습니다.
- 레시피 파싱 완료 알림 메시지에 레시피 제목을 포함하도록 개선했습니다.

<br>

## 🧩 관련 이슈

- related to #62

<br>

## 🛠 작업 상세

### ES 검색 페이징 버그 수정

기존에는 `NativeQuery` 빌드 시 `withMaxResults(pageSize + 1)`과 `withPageable(pageable)`을 함께 사용했습니다. Spring Data Elasticsearch 내부에서 `withPageable`이 size를 덮어쓰면서 `+1` 전략이 무효화되어, `hasNext` 판단용 추가 1건이 조회되지 않았습니다.

`withMaxResults`를 제거하고, `PageRequest.of(page, pageSize + 1)`로 Pageable 자체에 `+1`을 반영한 `slicePageable`을 만들어 전달하는 방식으로 변경했습니다. `executeSearch`에서는 원래 `pageable`의 `pageSize`를 기준으로 `hasNext`를 판단합니다.

**변경 대상**: `search()`, `searchForCuration()` 두 메서드 모두 동일하게 적용.

### 레시피 파싱 완료 알림에 레시피 제목 포함

기존 알림 메시지가 `"외부 레시피 파싱이 완료되어 저장되었어요."`로 고정되어 있어 어떤 레시피인지 구분할 수 없었습니다.

`NotificationEvent.importedRecipeCompleted`에 `recipeTitle` 파라미터를 추가하고, 메시지를 `"'레시피제목' 레시피가 저장되었어요."` 형식으로 변경했습니다. 다른 알림 메시지(`recipeName + " 레시피가 공유되었습니다."` 등)와 일관된 패턴입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **개선 사항**
  * 외부 레시피 임포트 완료 알림에서 이제 레시피 제목이 표시됩니다.
  * 검색 결과 페이지네이션 로직을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->