### PR TITLE
refactor : N+1 쿼리 개선

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,12 +128,37 @@ Repository는 Spring Data JPA와 QueryDSL을 함께 사용:
 ## 테스트
 
 ### 테스트 기반 클래스
-- `IntegrationTestBase` - Testcontainers MySQL + Elasticsearch, MockMvc와 ObjectMapper 제공
-- `UnitTestBase` - strict stubs 설정의 Mockito 사용
-- `@WithMockMember` - 테스트에서 인증된 사용자를 모킹하는 커스텀 어노테이션
+- `IntegrationTestBase` - `@ServiceConnection`으로 Testcontainers MySQL + Elasticsearch 자동 관리, MockMvc/ObjectMapper/JdbcTemplate 제공. 정적 컨테이너로 테스트 클래스 간 재사용
+- `UnitTestBase` - `STRICT_STUBS` 모드의 Mockito (미사용 stub은 에러). Spring 컨텍스트 미로드
+- `@WithMockMember` - 커스텀 인증 모킹. 커스터마이징: `@WithMockMember(id=2L, email="test@test.com", role=Role.ADMIN)`
 
 ### 테스트 프로필
-테스트는 `@ActiveProfiles("test")`로 Testcontainers MySQL/Elasticsearch 사용.
+테스트는 `@ActiveProfiles("test")`로 Testcontainers MySQL/Elasticsearch 사용. `ddl-auto: none` (Flyway가 스키마 관리).
+
+## CI/CD
+
+### GitHub Actions
+- **CI (`ci.yml`):** push/PR → main/develop에서 트리거. JDK 21 빌드+테스트, JaCoCo 커버리지 리포트 PR 코멘트
+- **CD Dev (`cd-dev.yml`):** develop push → Docker 이미지(linux/arm64) 빌드 → GHCR push → EC2 배포
+- **CD Prod (`cd-prod.yml`):** main push → 프로덕션 배포
+- 배포 스크립트: `scripts/deploy-*.sh`
+
+## 모니터링
+
+- Actuator 엔드포인트: `/actuator/health`, `/actuator/prometheus`
+- Micrometer Prometheus 메트릭 (application tag: `short-kki`)
+- 모니터링 스택: `monitoring/docker-compose.yml` (Prometheus:9090, Grafana:3000)
+
+## Git 컨벤션
+
+### 커밋 메시지
+- 형식: `{type}: {설명}` (예: `refactor: GroupService 북마크 보정 N+1 쿼리 배치 조회로 개선`)
+- type: `feat`, `fix`, `refactor`, `docs`, `test`, `chore` 등
+- 이슈 번호 참조: `(#{이슈번호})` 접미사 (예: `(#86)`)
+
+### 브랜치 네이밍
+- `feat/#{이슈번호}-설명`, `fix/#{이슈번호}-설명`, `refactor/#{이슈번호}-설명`
+- PR 대상 브랜치: `develop`
 
 ## 주요 컨벤션
 
@@ -143,3 +168,4 @@ Repository는 Spring Data JPA와 QueryDSL을 함께 사용:
 - 설정 속성은 `@ConfigurationProperties`로 바인딩 (예: `FileUploadProperties`, `OAuth2Properties`)
 - 예외는 `ErrorCode` enum에 정의 후 적절한 예외 클래스 사용
 - JPA `open-in-view: false`, `default_batch_fetch_size: 100` 설정
+- 검증 로직은 `*ValidationService` 클래스로 분리 (예: `GroupValidationService`, `RecipeBookValidationService`)

--- a/src/main/java/com/shortkki/api/group/application/service/GroupService.java
+++ b/src/main/java/com/shortkki/api/group/application/service/GroupService.java
@@ -310,12 +310,11 @@ public class GroupService {
             return;
         }
 
-        List<Long> allRecipeIds = books.stream()
-                .flatMap(book -> recipeBookItemRepository.findRecipeIdsByRecipeBookId(book.getId()).stream())
-                .distinct()
-                .toList();
+        List<Long> bookIds = books.stream().map(RecipeBook::getId).toList();
 
+        List<Long> allRecipeIds = recipeBookItemRepository.findRecipeIdsByRecipeBookIds(bookIds);
         if (allRecipeIds.isEmpty()) {
+            recipeBookItemRepository.deleteAllByRecipeBookIds(bookIds);
             return;
         }
 
@@ -330,9 +329,7 @@ public class GroupService {
             recipeRepository.decrementBookmarkCountBulk(recipeIdsToDecrement);
         }
 
-        for (RecipeBook book : books) {
-            recipeBookItemRepository.deleteAllByRecipeBookId(book.getId());
-        }
+        recipeBookItemRepository.deleteAllByRecipeBookIds(bookIds);
     }
 
     private InviteLink getOrCreateValidInviteLink(Group group) {

--- a/src/main/java/com/shortkki/api/recipe/repository/RecipeIngredientRepository.java
+++ b/src/main/java/com/shortkki/api/recipe/repository/RecipeIngredientRepository.java
@@ -12,6 +12,8 @@ public interface RecipeIngredientRepository extends JpaRepository<RecipeIngredie
 
     List<RecipeIngredient> findByRecipeId(Long recipeId);
 
+    List<RecipeIngredient> findByRecipeIdIn(List<Long> recipeIds);
+
     void deleteByRecipeId(Long recipeId);
 
     @Query("SELECT ri FROM RecipeIngredient ri JOIN FETCH ri.ingredient WHERE ri.id IN :ids")

--- a/src/main/java/com/shortkki/api/recipe/repository/RecipeRepository.java
+++ b/src/main/java/com/shortkki/api/recipe/repository/RecipeRepository.java
@@ -15,6 +15,9 @@ public interface RecipeRepository extends JpaRepository<Recipe, Long> {
 
     boolean existsBySourceContentId(Long sourceContentId);
 
+    @Query("SELECT r.id FROM Recipe r WHERE r.isActive = true")
+    List<Long> findAllActiveIds();
+
     @Query("""
             SELECT r FROM Recipe r
             LEFT JOIN FETCH r.member

--- a/src/main/java/com/shortkki/api/recipe/repository/RecipeStepRepository.java
+++ b/src/main/java/com/shortkki/api/recipe/repository/RecipeStepRepository.java
@@ -8,5 +8,7 @@ public interface RecipeStepRepository extends JpaRepository<RecipeStep, Long> {
 
     List<RecipeStep> findByRecipeId(Long recipeId);
 
+    List<RecipeStep> findByRecipeIdIn(List<Long> recipeIds);
+
     void deleteByRecipeId(Long recipeId);
 }

--- a/src/main/java/com/shortkki/api/recipe/repository/RecipeTagRepository.java
+++ b/src/main/java/com/shortkki/api/recipe/repository/RecipeTagRepository.java
@@ -28,6 +28,15 @@ public interface RecipeTagRepository extends JpaRepository<RecipeTag, Long> {
             """)
     List<String> findTagNamesByRecipeId(@Param("recipeId") Long recipeId);
 
+    @Query("""
+                select rt.recipeId, t.name
+                from RecipeTag rt
+                join Tag t
+                    on t.id = rt.tagId
+                where rt.recipeId in :recipeIds
+            """)
+    List<Object[]> findTagNamesByRecipeIdIn(@Param("recipeIds") List<Long> recipeIds);
+
     @Modifying
     @Query("delete from RecipeTag rt where rt.recipeId = :recipeId")
     void deleteByRecipeId(@Param("recipeId") Long recipeId);

--- a/src/main/java/com/shortkki/api/recipe/service/RecipeQueryService.java
+++ b/src/main/java/com/shortkki/api/recipe/service/RecipeQueryService.java
@@ -12,6 +12,8 @@ import com.shortkki.api.recipeBook.service.RecipeBookService;
 import com.shortkki.global.error.ErrorCode;
 import com.shortkki.global.error.exception.NotFoundException;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -40,9 +42,29 @@ public class RecipeQueryService {
     // TODO: 페이지네이션
     public List<RecipeResponse> getAll() {
         List<Recipe> recipes = recipeRepository.findAll();
+        List<Long> recipeIds = recipes.stream().map(Recipe::getId).toList();
+
+        Map<Long, List<RecipeStep>> stepsMap = recipeStepRepository.findByRecipeIdIn(recipeIds)
+                .stream()
+                .collect(Collectors.groupingBy(step -> step.getRecipe().getId()));
+
+        Map<Long, List<RecipeIngredient>> ingredientsMap = recipeIngredientRepository.findByRecipeIdIn(recipeIds)
+                .stream()
+                .collect(Collectors.groupingBy(ing -> ing.getRecipe().getId()));
+
+        Map<Long, List<String>> tagsMap = recipeTagRepository.findTagNamesByRecipeIdIn(recipeIds)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        row -> (Long) row[0],
+                        Collectors.mapping(row -> (String) row[1], Collectors.toList())));
 
         return recipes.stream()
-                .map(recipe -> toRecipeResponse(recipe, null))
+                .map(recipe -> RecipeResponse.toDto(
+                        recipe,
+                        stepsMap.getOrDefault(recipe.getId(), List.of()),
+                        ingredientsMap.getOrDefault(recipe.getId(), List.of()),
+                        tagsMap.getOrDefault(recipe.getId(), List.of()),
+                        List.of()))
                 .toList();
     }
 

--- a/src/main/java/com/shortkki/api/recipe/service/RecipeQueryService.java
+++ b/src/main/java/com/shortkki/api/recipe/service/RecipeQueryService.java
@@ -41,11 +41,11 @@ public class RecipeQueryService {
 
     // TODO: 페이지네이션
     public List<RecipeResponse> getAll() {
-        List<Recipe> recipes = recipeRepository.findAll();
-        if (recipes.isEmpty()) {
+        List<Long> recipeIds = recipeRepository.findAllActiveIds();
+        if (recipeIds.isEmpty()) {
             return List.of();
         }
-        List<Long> recipeIds = recipes.stream().map(Recipe::getId).toList();
+        List<Recipe> recipes = recipeRepository.findActiveByIdsWithAssociations(recipeIds);
 
         Map<Long, List<RecipeStep>> stepsMap = recipeStepRepository.findByRecipeIdIn(recipeIds)
                 .stream()

--- a/src/main/java/com/shortkki/api/recipe/service/RecipeQueryService.java
+++ b/src/main/java/com/shortkki/api/recipe/service/RecipeQueryService.java
@@ -42,6 +42,9 @@ public class RecipeQueryService {
     // TODO: 페이지네이션
     public List<RecipeResponse> getAll() {
         List<Recipe> recipes = recipeRepository.findAll();
+        if (recipes.isEmpty()) {
+            return List.of();
+        }
         List<Long> recipeIds = recipes.stream().map(Recipe::getId).toList();
 
         Map<Long, List<RecipeStep>> stepsMap = recipeStepRepository.findByRecipeIdIn(recipeIds)

--- a/src/main/java/com/shortkki/api/recipeBook/repository/RecipeBookItemRepository.java
+++ b/src/main/java/com/shortkki/api/recipeBook/repository/RecipeBookItemRepository.java
@@ -64,6 +64,13 @@ public interface RecipeBookItemRepository extends JpaRepository<RecipeBookItem, 
   @Query("SELECT rbi.recipe.id FROM RecipeBookItem rbi WHERE rbi.recipeBook.id = :recipeBookId")
   List<Long> findRecipeIdsByRecipeBookId(@Param("recipeBookId") Long recipeBookId);
 
+  @Query("SELECT DISTINCT rbi.recipe.id FROM RecipeBookItem rbi WHERE rbi.recipeBook.id IN :recipeBookIds")
+  List<Long> findRecipeIdsByRecipeBookIds(@Param("recipeBookIds") List<Long> recipeBookIds);
+
+  @Modifying
+  @Query("DELETE FROM RecipeBookItem rbi WHERE rbi.recipeBook.id IN :recipeBookIds")
+  void deleteAllByRecipeBookIds(@Param("recipeBookIds") List<Long> recipeBookIds);
+
   @Query("""
       select i from RecipeBookItem i
       join fetch i.recipe

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -16,6 +16,7 @@ spring:
       hibernate:
         globally_quoted_identifiers: true
         globally_quoted_identifiers_skip_column_definitions: true
+        generate_statistics: true
 #        show_sql: true
 #        format_sql: true
 


### PR DESCRIPTION
## 🔥 변경 사항
- RecipeQueryService.getAll()에서 루프 내 Repository 직접 호출로 발생하던 N+1 쿼리를 IN절 배치 조회 + Map 조립 방식으로 개선 
- 그룹 삭제 시 레시피북마다 루프를 돌며 개별 조회/삭제하던 쿼리를 IN절 배치 쿼리로 통합하여 1+2N → 3으로 고정
<br>

## 🧩 관련 이슈
- related to #86 

<br>

## 🛠 작업 내용
- [x] RecipeQueryService.getAll() 개선
- [x] GroupService.decrementBookmarkCountsForGroup() 개선

<br>

## 📸 스크린샷 / 결과 (선택)
### RecipeQueryService.getAll()
                                                                                                                                                        
레시피 전체를 조회하는 1번의 쿼리가 실행된 뒤, 각 레시피마다 steps, ingredients, tags를 가져오기 위해 3개의 추가 쿼리가 실행된다.                   

  527625074 nanoseconds spent preparing 30092 JDBC statements;
  2355287700 nanoseconds spent executing 30092 JDBC statements;

  레시피 10,030개 기준:
  - 30,092 쿼리 : 1(findAll) + 10,030×3(steps/ingredients/tags) + 1(member batch) = 30,092
  - 실행 시간 : 2,355ms (약 2.4초)

  1차 개선 : 배치 조회 후 Map으로 조립

  10249375 nanoseconds spent preparing 5 JDBC statements;
  179357084 nanoseconds spent executing 5 JDBC statements;

  - 5 쿼리 : 1(findAll) + 3(steps/ingredients/tags) + 1(member LAZY 배치 로드)
  - 실행 시간 : 179ms
  - 단, 5번째 쿼리는 Hibernate의 default_batch_fetch_size에 의한 암묵적 LAZY 프록시 초기화로, 더미 데이터 특성(동일 작성자, sourceContent/mainImgFile 없음)에 의존한 결과

  2차 개선 : JOIN FETCH로 LAZY 프록시 초기화 제거

  - findAll() → findAllActiveIds() + findActiveByIdsWithAssociations()로 전환
  - Member, SourceContent, SourceCreator, MainImgFile을 JOIN FETCH로 한 번에 조회
  - 5 쿼리 : 1(findAllActiveIds) + 1(findActiveByIdsWithAssociations) + 3(steps/ingredients/tags)
  - 쿼리 수는 동일하지만, 데이터 특성과 무관하게 항상 고정 5 쿼리 보장

  최종 결과: 쿼리 수 30,092 → 5회(99.98% 감소), 실행 시간 2,355ms → 179ms(13배 개선)


### GroupService.decrementBookmarkCountsForGroup()
레시피북 목록을 조회한 후, 각 레시피북마다 findRecipeIdsByRecipeBookId()를 호출하고, 삭제도 레시피북 단위로 루프를 돌린다.
<해결 : IN절 배치 쿼리>
기존에는 레시피북마다 루프 안에서 레시피 ID 조회와 삭제 쿼리를 각각 호출했던 것을, 레시피북 ID 목록을 모아 WHERE recipe_book_id IN (...) 으로 한 번에 조회하고 한 번에 삭제하는 방식으로 변경했습니다. 레시피북 N개 기준, 쿼리 수가 1+2N에서 3으로 고정됩니다. 
레시피북 수에 무관하게 쿼리 수 고정되는 상태라 따로 성능을 측정하진 않았습니다.
<br>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **성능 개선**
  * 여러 레시피의 재료, 조리 단계, 태그 정보를 보다 효율적으로 조회할 수 있도록 개선되었습니다.
  * 레시피 데이터 배치 처리 최적화로 전체 레시피 조회 성능이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->