### PR TITLE
fix : 피드 목록 조회 시 레시피 미연결 피드 NPE 수정

### DIFF
--- a/src/main/java/com/shortkki/api/feed/repository/FeedRepositoryImpl.java
+++ b/src/main/java/com/shortkki/api/feed/repository/FeedRepositoryImpl.java
@@ -2,7 +2,10 @@ package com.shortkki.api.feed.repository;
 
 import com.shortkki.api.feed.entity.Feed;
 import com.shortkki.api.feed.entity.QFeed;
+import com.shortkki.api.file.entity.QFileMetadata;
 import com.shortkki.api.group.entity.Group;
+import com.shortkki.api.member.entity.QMember;
+import com.shortkki.api.recipe.entity.QRecipe;
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -24,6 +27,10 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
     private final QFeed feed = QFeed.feed;
+    private final QRecipe recipe = QRecipe.recipe;
+    private final QMember recipeAuthor = new QMember("recipeAuthor");
+    private final QFileMetadata recipeMainImg = new QFileMetadata("recipeMainImg");
+    private final QFileMetadata recipeAuthorProfileImg = new QFileMetadata("recipeAuthorProfileImg");
 
     @Override
     public List<Feed> findAllByGroupWithMember(Group group) {
@@ -43,10 +50,10 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
                 .selectFrom(feed)
                 .join(feed.member).fetchJoin()
                 .leftJoin(feed.member.profileImgFile).fetchJoin()
-                .leftJoin(feed.recipe).fetchJoin()
-                .leftJoin(feed.recipe.mainImgFile).fetchJoin()
-                .leftJoin(feed.recipe.member).fetchJoin()
-                .leftJoin(feed.recipe.member.profileImgFile).fetchJoin()
+                .leftJoin(feed.recipe, recipe).fetchJoin()
+                .leftJoin(recipe.mainImgFile, recipeMainImg).fetchJoin()
+                .leftJoin(recipe.member, recipeAuthor).fetchJoin()
+                .leftJoin(recipeAuthor.profileImgFile, recipeAuthorProfileImg).fetchJoin()
                 .where(
                         feed.group.eq(group),
                         cursorIdCondition(cursorId)


### PR DESCRIPTION
## 🔥 변경 사항
QueryDSL leftJoin 중첩 경로 직접 참조 시 NPE 발생하는 문제를 별도 Q타입 alias 사용으로 해결


<br>

## 🧩 관련 이슈
- related to #88 
- closes #88

<br>

## 🛠 작업 내용
- [x] FeedRepositoryImpl.findByGroupWithCursor() 수정

<br>

## 📸 스크린샷 / 결과 (선택)
피드 목록 조회 API(`GET /api/v1/groups/{groupId}/feeds`) 호출 시 500 에러 발생

```
java.lang.NullPointerException: Cannot invoke "com.querydsl.core.types.Expression.accept(...)" because "expr" is null
    at com.shortkki.api.feed.repository.FeedRepositoryImpl.findByGroupWithCursor(FeedRepositoryImpl.java:49)
```
그룹 내에 레시피가 연결되지 않은 피드(`recipe_id = NULL`)가 존재할 때 피드 목록 조회 시 NPE 발생
## 원인

`FeedRepositoryImpl.findByGroupWithCursor()`에서 `feed.recipe`를 `leftJoin`한 뒤, 하위 경로를 직접 참조한 것이 문제

```java
// 문제 코드
.leftJoin(feed.recipe).fetchJoin()
.leftJoin(feed.recipe.mainImgFile).fetchJoin()           // NPE
.leftJoin(feed.recipe.member).fetchJoin()                 // NPE
.leftJoin(feed.recipe.member.profileImgFile).fetchJoin()  // NPE
```

QueryDSL은 `feed.recipe.mainImgFile`같은 중첩 경로를 해석할 때 내부적으로 `feed.recipe`의 expression을 먼저 resolve하는데, `leftJoin`으로 선언한 경로는 이 시점에 expression이 null로 평가되어 NPE가 발생한다.

## 해결

별도 Q타입 alias를 선언하고, `leftJoin(source, alias)` 형태로 명시적 alias를 사용

```java
// 수정 코드
.leftJoin(feed.recipe, recipe).fetchJoin()
.leftJoin(recipe.mainImgFile, recipeMainImg).fetchJoin()
.leftJoin(recipe.member, recipeAuthor).fetchJoin()
.leftJoin(recipeAuthor.profileImgFile, recipeAuthorProfileImg).fetchJoin()
```

alias를 통해 접근하면 QueryDSL이 이미 선언된 변수로 경로를 해석하므로 recipe가 null이든 아니든 쿼리가 정상 생성된다. 실제 생성되는 SQL은 동일한 `LEFT JOIN`이다.

<br>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 내부 쿼리를 명시적 별칭 기반 조인으로 재구성해 가독성과 일관성을 개선했습니다.
  * 중첩 경로 체이닝을 줄이고 조인 구조를 평탄화하여 복잡도를 낮추고 유지보수성을 강화했습니다.
  * 데이터 조회 흐름을 정돈해 향후 확장 시 충돌 가능성을 줄였습니다.
  * 외부 동작과 공개 API에는 변화가 없으며, 기존 기능과 결과에는 영향이 없습니다.
  * 쿼리 플랜 명확성 향상으로 성능·안정성이 소폭 개선될 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->