### PR TITLE
feat: Redis 기반 Refresh Token Rotation 및 AT 블랙리스트 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // Database
     implementation 'org.flywaydb:flyway-core'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,16 @@ services:
     depends_on:
       - elasticsearch
 
+  redis:
+    image: redis:7-alpine
+    container_name: local-redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+
 volumes:
   mysql-data:
   es-data:
+  redis-data:

--- a/src/main/java/com/shortkki/api/auth/application/port/AccessTokenBlacklist.java
+++ b/src/main/java/com/shortkki/api/auth/application/port/AccessTokenBlacklist.java
@@ -4,7 +4,7 @@ import java.time.Duration;
 
 public interface AccessTokenBlacklist {
 
-    void add(String accessToken, Duration ttl);
+    void add(String jti, Duration ttl);
 
-    boolean isBlacklisted(String accessToken);
+    boolean isBlacklisted(String jti);
 }

--- a/src/main/java/com/shortkki/api/auth/application/port/AccessTokenBlacklist.java
+++ b/src/main/java/com/shortkki/api/auth/application/port/AccessTokenBlacklist.java
@@ -1,0 +1,10 @@
+package com.shortkki.api.auth.application.port;
+
+import java.time.Duration;
+
+public interface AccessTokenBlacklist {
+
+    void add(String accessToken, Duration ttl);
+
+    boolean isBlacklisted(String accessToken);
+}

--- a/src/main/java/com/shortkki/api/auth/application/port/RefreshTokenStore.java
+++ b/src/main/java/com/shortkki/api/auth/application/port/RefreshTokenStore.java
@@ -6,6 +6,15 @@ public interface RefreshTokenStore {
 
     void store(Long memberId, String refreshToken, Duration ttl);
 
+    /**
+     * 원자적 토큰 로테이션 (compare-and-swap).
+     * 저장된 RT가 expectedToken과 일치하면 newToken으로 교체한다.
+     *
+     * @return 일치하여 교체 성공하면 true, 불일치(탈취 감지)면 false
+     * @throws com.shortkki.global.error.exception.BusinessException 저장된 RT가 없으면 REFRESH_TOKEN_NOT_FOUND
+     */
+    boolean rotate(Long memberId, String expectedToken, String newToken, Duration ttl);
+
     String find(Long memberId);
 
     void delete(Long memberId);

--- a/src/main/java/com/shortkki/api/auth/application/port/RefreshTokenStore.java
+++ b/src/main/java/com/shortkki/api/auth/application/port/RefreshTokenStore.java
@@ -1,0 +1,12 @@
+package com.shortkki.api.auth.application.port;
+
+import java.time.Duration;
+
+public interface RefreshTokenStore {
+
+    void store(Long memberId, String refreshToken, Duration ttl);
+
+    String find(Long memberId);
+
+    void delete(Long memberId);
+}

--- a/src/main/java/com/shortkki/api/auth/application/service/AuthService.java
+++ b/src/main/java/com/shortkki/api/auth/application/service/AuthService.java
@@ -29,6 +29,7 @@ import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Objects;
 
@@ -44,9 +45,6 @@ public class AuthService {
     private final GoogleIdTokenVerifierService googleIdTokenVerifierService;
     private final RefreshTokenStore refreshTokenStore;
     private final AccessTokenBlacklist accessTokenBlacklist;
-
-    @Value("${jwt.access-token-validity}")
-    private long accessTokenValidityMs;
 
     @Value("${jwt.refresh-token-validity}")
     private long refreshTokenValidityMs;
@@ -375,10 +373,14 @@ public class AuthService {
         return new RefreshTokenResponse(newAccessToken, newRefreshToken);
     }
 
-    public void logout(Long memberId, String jti) {
+    public void logout(Long memberId, String jti, Instant exp) {
         refreshTokenStore.delete(memberId);
-        accessTokenBlacklist.add(jti, Duration.ofMillis(accessTokenValidityMs));
-        log.info("[RTR] 로그아웃 — memberId: {}, AT jti 블랙리스트 등록", memberId);
+        Duration remainingValidity = Duration.between(Instant.now(), exp);
+        if (remainingValidity.isNegative()) {
+            remainingValidity = Duration.ZERO;
+        }
+        accessTokenBlacklist.add(jti, remainingValidity);
+        log.info("[RTR] 로그아웃 — memberId: {}, AT jti 블랙리스트 등록, TTL: {}s", memberId, remainingValidity.getSeconds());
     }
 
     private String createAndStoreRefreshToken(Long memberId) {

--- a/src/main/java/com/shortkki/api/auth/application/service/AuthService.java
+++ b/src/main/java/com/shortkki/api/auth/application/service/AuthService.java
@@ -375,7 +375,8 @@ public class AuthService {
     public void logout(String accessToken, String refreshToken) {
         Long memberId = jwtTokenProvider.getMemberIdFromToken(refreshToken);
         refreshTokenStore.delete(memberId);
-        accessTokenBlacklist.add(accessToken, jwtTokenProvider.getRemainingValidity(accessToken));
+        String jti = jwtTokenProvider.getJti(accessToken);
+        accessTokenBlacklist.add(jti, jwtTokenProvider.getRemainingValidity(accessToken));
     }
 
     private String createAndStoreRefreshToken(Long memberId) {

--- a/src/main/java/com/shortkki/api/auth/application/service/AuthService.java
+++ b/src/main/java/com/shortkki/api/auth/application/service/AuthService.java
@@ -45,6 +45,9 @@ public class AuthService {
     private final RefreshTokenStore refreshTokenStore;
     private final AccessTokenBlacklist accessTokenBlacklist;
 
+    @Value("${jwt.access-token-validity}")
+    private long accessTokenValidityMs;
+
     @Value("${jwt.refresh-token-validity}")
     private long refreshTokenValidityMs;
 
@@ -349,34 +352,37 @@ public class AuthService {
             throw new BadRequestException(ErrorCode.INVALID_TOKEN);
         }
 
-        String storedToken = refreshTokenStore.find(memberId);
-        if (storedToken == null) {
-            throw new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
-        }
-
-        if (!storedToken.equals(refreshToken)) {
-            refreshTokenStore.delete(memberId);
-            throw new BusinessException(ErrorCode.REFRESH_TOKEN_REUSED);
-        }
-
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(memberId);
+        Duration ttl = Duration.ofMillis(refreshTokenValidityMs);
+
+        // Lua 스크립트로 원자적 CAS: 저장된 RT == 제출된 RT이면 새 RT로 교체
+        boolean rotated = refreshTokenStore.rotate(memberId, refreshToken, newRefreshToken, ttl);
+        if (!rotated) {
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_REUSED);
+        }
 
         String newAccessToken = jwtTokenProvider.createAccessToken(
                 member.getId(),
                 member.getEmail(),
                 member.getRole()
         );
-        String newRefreshToken = createAndStoreRefreshToken(member.getId());
 
         return new RefreshTokenResponse(newAccessToken, newRefreshToken);
     }
 
-    public void logout(String accessToken, String refreshToken) {
-        Long memberId = jwtTokenProvider.getMemberIdFromToken(refreshToken);
+    public void logout(Long memberId, String jti, String refreshToken) {
+        validateRefreshToken(refreshToken);
+
+        Long rtMemberId = jwtTokenProvider.getMemberIdFromToken(refreshToken);
+        if (!Objects.equals(memberId, rtMemberId)) {
+            throw new BadRequestException(ErrorCode.INVALID_TOKEN);
+        }
+
         refreshTokenStore.delete(memberId);
-        String jti = jwtTokenProvider.getJti(accessToken);
-        accessTokenBlacklist.add(jti, jwtTokenProvider.getRemainingValidity(accessToken));
+        accessTokenBlacklist.add(jti, Duration.ofMillis(accessTokenValidityMs));
     }
 
     private String createAndStoreRefreshToken(Long memberId) {

--- a/src/main/java/com/shortkki/api/auth/application/service/AuthService.java
+++ b/src/main/java/com/shortkki/api/auth/application/service/AuthService.java
@@ -1,5 +1,7 @@
 package com.shortkki.api.auth.application.service;
 
+import com.shortkki.api.auth.application.port.AccessTokenBlacklist;
+import com.shortkki.api.auth.application.port.RefreshTokenStore;
 import com.shortkki.api.auth.dto.LoginRequest;
 import com.shortkki.api.auth.dto.LoginResponse;
 import com.shortkki.api.auth.dto.RefreshTokenResponse;
@@ -15,14 +17,18 @@ import com.shortkki.global.error.ErrorCode;
 import com.shortkki.global.error.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
 
@@ -36,6 +42,11 @@ public class AuthService {
     private final MemberRepository memberRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final GoogleIdTokenVerifierService googleIdTokenVerifierService;
+    private final RefreshTokenStore refreshTokenStore;
+    private final AccessTokenBlacklist accessTokenBlacklist;
+
+    @Value("${jwt.refresh-token-validity}")
+    private long refreshTokenValidityMs;
 
     @Transactional
     public LoginResponse login(OAuthProvider provider, LoginRequest request) {
@@ -75,7 +86,7 @@ public class AuthService {
                 member.getId(),
                 member.getEmail(),
                 member.getRole());
-        String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+        String refreshToken = createAndStoreRefreshToken(member.getId());
 
         return LoginResponse.builder()
                 .memberId(member.getId())
@@ -109,7 +120,7 @@ public class AuthService {
                 member.getId(),
                 member.getEmail(),
                 member.getRole());
-        String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+        String refreshToken = createAndStoreRefreshToken(member.getId());
 
         return LoginResponse.builder()
                 .memberId(member.getId())
@@ -152,7 +163,7 @@ public class AuthService {
                 member.getId(),
                 member.getEmail(),
                 member.getRole());
-        String refreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+        String refreshToken = createAndStoreRefreshToken(member.getId());
 
         return LoginResponse.builder()
                 .memberId(member.getId())
@@ -326,7 +337,7 @@ public class AuthService {
         return memberRepository.save(newMember);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public RefreshTokenResponse refreshAccessToken(String accessToken, String refreshToken) {
         validateAccessTokenForRefresh(accessToken);
         validateRefreshToken(refreshToken);
@@ -338,6 +349,16 @@ public class AuthService {
             throw new BadRequestException(ErrorCode.INVALID_TOKEN);
         }
 
+        String storedToken = refreshTokenStore.find(memberId);
+        if (storedToken == null) {
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+        }
+
+        if (!storedToken.equals(refreshToken)) {
+            refreshTokenStore.delete(memberId);
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_REUSED);
+        }
+
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundException(ErrorCode.MEMBER_NOT_FOUND));
 
@@ -346,9 +367,33 @@ public class AuthService {
                 member.getEmail(),
                 member.getRole()
         );
-        String newRefreshToken = jwtTokenProvider.createRefreshToken(member.getId());
+        String newRefreshToken = createAndStoreRefreshToken(member.getId());
 
         return new RefreshTokenResponse(newAccessToken, newRefreshToken);
+    }
+
+    public void logout(String accessToken, String refreshToken) {
+        Long memberId = jwtTokenProvider.getMemberIdFromToken(refreshToken);
+        refreshTokenStore.delete(memberId);
+        accessTokenBlacklist.add(accessToken, jwtTokenProvider.getRemainingValidity(accessToken));
+    }
+
+    private String createAndStoreRefreshToken(Long memberId) {
+        String rt = jwtTokenProvider.createRefreshToken(memberId);
+        Duration ttl = Duration.ofMillis(refreshTokenValidityMs);
+
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    refreshTokenStore.store(memberId, rt, ttl);
+                }
+            });
+        } else {
+            refreshTokenStore.store(memberId, rt, ttl);
+        }
+
+        return rt;
     }
 
     private void validateAccessTokenForRefresh(String accessToken) {

--- a/src/main/java/com/shortkki/api/auth/application/service/AuthService.java
+++ b/src/main/java/com/shortkki/api/auth/application/service/AuthService.java
@@ -361,6 +361,7 @@ public class AuthService {
         // Lua 스크립트로 원자적 CAS: 저장된 RT == 제출된 RT이면 새 RT로 교체
         boolean rotated = refreshTokenStore.rotate(memberId, refreshToken, newRefreshToken, ttl);
         if (!rotated) {
+            log.warn("[RTR] 탈취 감지 — memberId: {}, RT 재사용 시도", memberId);
             throw new BusinessException(ErrorCode.REFRESH_TOKEN_REUSED);
         }
 
@@ -370,19 +371,14 @@ public class AuthService {
                 member.getRole()
         );
 
+        log.info("[RTR] 토큰 갱신 성공 — memberId: {}", memberId);
         return new RefreshTokenResponse(newAccessToken, newRefreshToken);
     }
 
-    public void logout(Long memberId, String jti, String refreshToken) {
-        validateRefreshToken(refreshToken);
-
-        Long rtMemberId = jwtTokenProvider.getMemberIdFromToken(refreshToken);
-        if (!Objects.equals(memberId, rtMemberId)) {
-            throw new BadRequestException(ErrorCode.INVALID_TOKEN);
-        }
-
+    public void logout(Long memberId, String jti) {
         refreshTokenStore.delete(memberId);
         accessTokenBlacklist.add(jti, Duration.ofMillis(accessTokenValidityMs));
+        log.info("[RTR] 로그아웃 — memberId: {}, AT jti 블랙리스트 등록", memberId);
     }
 
     private String createAndStoreRefreshToken(Long memberId) {

--- a/src/main/java/com/shortkki/api/auth/controller/AuthController.java
+++ b/src/main/java/com/shortkki/api/auth/controller/AuthController.java
@@ -4,7 +4,6 @@ import com.shortkki.api.auth.application.service.AuthService;
 import com.shortkki.api.auth.application.usecase.RegisterUserUseCase;
 import com.shortkki.api.auth.dto.LoginRequest;
 import com.shortkki.api.auth.dto.LoginResponse;
-import com.shortkki.api.auth.dto.LogoutRequest;
 import com.shortkki.api.auth.dto.RefreshTokenRequest;
 import com.shortkki.api.auth.dto.RefreshTokenResponse;
 import com.shortkki.api.member.entity.OAuthProvider;
@@ -43,13 +42,5 @@ public class AuthController {
                 request.refreshToken()
         );
         return ResponseEntity.ok(BaseResponse.success("토큰 재발급 성공", response));
-    }
-
-    @PostMapping("/logout")
-    public ResponseEntity<BaseResponse<Void>> logout(
-            @Valid @RequestBody LogoutRequest request
-    ) {
-        authService.logout(request.accessToken(), request.refreshToken());
-        return ResponseEntity.ok(BaseResponse.success("로그아웃 성공", null));
     }
 }

--- a/src/main/java/com/shortkki/api/auth/controller/AuthController.java
+++ b/src/main/java/com/shortkki/api/auth/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.shortkki.api.auth.application.service.AuthService;
 import com.shortkki.api.auth.application.usecase.RegisterUserUseCase;
 import com.shortkki.api.auth.dto.LoginRequest;
 import com.shortkki.api.auth.dto.LoginResponse;
+import com.shortkki.api.auth.dto.LogoutRequest;
 import com.shortkki.api.auth.dto.RefreshTokenRequest;
 import com.shortkki.api.auth.dto.RefreshTokenResponse;
 import com.shortkki.api.member.entity.OAuthProvider;
@@ -33,7 +34,6 @@ public class AuthController {
         return ResponseEntity.ok(BaseResponse.success("로그인에 성공했습니다.", response));
     }
 
-    // TODO : RT 로테이션 도입 및 레디스
     @PostMapping("/refresh")
     public ResponseEntity<BaseResponse<RefreshTokenResponse>> refresh(
             @Valid @RequestBody RefreshTokenRequest request
@@ -45,5 +45,11 @@ public class AuthController {
         return ResponseEntity.ok(BaseResponse.success("토큰 재발급 성공", response));
     }
 
-
+    @PostMapping("/logout")
+    public ResponseEntity<BaseResponse<Void>> logout(
+            @Valid @RequestBody LogoutRequest request
+    ) {
+        authService.logout(request.accessToken(), request.refreshToken());
+        return ResponseEntity.ok(BaseResponse.success("로그아웃 성공", null));
+    }
 }

--- a/src/main/java/com/shortkki/api/auth/controller/LogoutController.java
+++ b/src/main/java/com/shortkki/api/auth/controller/LogoutController.java
@@ -1,0 +1,31 @@
+package com.shortkki.api.auth.controller;
+
+import com.shortkki.api.auth.application.service.AuthService;
+import com.shortkki.api.auth.dto.LogoutRequest;
+import com.shortkki.global.auth.dto.LoginMember;
+import com.shortkki.global.response.BaseResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class LogoutController {
+
+    private final AuthService authService;
+
+    @PostMapping("/logout")
+    public ResponseEntity<BaseResponse<Void>> logout(
+            @AuthenticationPrincipal LoginMember loginMember,
+            @Valid @RequestBody LogoutRequest request
+    ) {
+        authService.logout(loginMember.getId(), loginMember.getJti(), request.refreshToken());
+        return ResponseEntity.ok(BaseResponse.success("로그아웃 성공", null));
+    }
+}

--- a/src/main/java/com/shortkki/api/auth/controller/LogoutController.java
+++ b/src/main/java/com/shortkki/api/auth/controller/LogoutController.java
@@ -1,15 +1,12 @@
 package com.shortkki.api.auth.controller;
 
 import com.shortkki.api.auth.application.service.AuthService;
-import com.shortkki.api.auth.dto.LogoutRequest;
 import com.shortkki.global.auth.dto.LoginMember;
 import com.shortkki.global.response.BaseResponse;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,10 +19,9 @@ public class LogoutController {
 
     @PostMapping("/logout")
     public ResponseEntity<BaseResponse<Void>> logout(
-            @AuthenticationPrincipal LoginMember loginMember,
-            @Valid @RequestBody LogoutRequest request
+            @AuthenticationPrincipal LoginMember loginMember
     ) {
-        authService.logout(loginMember.getId(), loginMember.getJti(), request.refreshToken());
-        return ResponseEntity.ok(BaseResponse.success("로그아웃 성공", null));
+        authService.logout(loginMember.getId(), loginMember.getJti());
+        return ResponseEntity.ok(BaseResponse.success());
     }
 }

--- a/src/main/java/com/shortkki/api/auth/controller/LogoutController.java
+++ b/src/main/java/com/shortkki/api/auth/controller/LogoutController.java
@@ -21,7 +21,7 @@ public class LogoutController {
     public ResponseEntity<BaseResponse<Void>> logout(
             @AuthenticationPrincipal LoginMember loginMember
     ) {
-        authService.logout(loginMember.getId(), loginMember.getJti());
+        authService.logout(loginMember.getId(), loginMember.getJti(), loginMember.getExp());
         return ResponseEntity.ok(BaseResponse.success());
     }
 }

--- a/src/main/java/com/shortkki/api/auth/dto/LogoutRequest.java
+++ b/src/main/java/com/shortkki/api/auth/dto/LogoutRequest.java
@@ -3,8 +3,6 @@ package com.shortkki.api.auth.dto;
 import jakarta.validation.constraints.NotBlank;
 
 public record LogoutRequest(
-        @NotBlank(message = "accessToken은 비어있을 수 없습니다.")
-        String accessToken,
         @NotBlank(message = "refreshToken은 비어있을 수 없습니다.")
         String refreshToken
 ) {

--- a/src/main/java/com/shortkki/api/auth/dto/LogoutRequest.java
+++ b/src/main/java/com/shortkki/api/auth/dto/LogoutRequest.java
@@ -1,0 +1,11 @@
+package com.shortkki.api.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LogoutRequest(
+        @NotBlank(message = "accessToken은 비어있을 수 없습니다.")
+        String accessToken,
+        @NotBlank(message = "refreshToken은 비어있을 수 없습니다.")
+        String refreshToken
+) {
+}

--- a/src/main/java/com/shortkki/api/auth/dto/LogoutRequest.java
+++ b/src/main/java/com/shortkki/api/auth/dto/LogoutRequest.java
@@ -1,9 +1,0 @@
-package com.shortkki.api.auth.dto;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record LogoutRequest(
-        @NotBlank(message = "refreshToken은 비어있을 수 없습니다.")
-        String refreshToken
-) {
-}

--- a/src/main/java/com/shortkki/api/auth/infra/redis/RedisAccessTokenBlacklist.java
+++ b/src/main/java/com/shortkki/api/auth/infra/redis/RedisAccessTokenBlacklist.java
@@ -1,0 +1,33 @@
+package com.shortkki.api.auth.infra.redis;
+
+import com.shortkki.api.auth.application.port.AccessTokenBlacklist;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisAccessTokenBlacklist implements AccessTokenBlacklist {
+
+    private static final String KEY_PREFIX = "bl:at:";
+    private static final String BLACKLISTED = "1";
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Override
+    public void add(String accessToken, Duration ttl) {
+        if (ttl.isPositive()) {
+            stringRedisTemplate.opsForValue().set(key(accessToken), BLACKLISTED, ttl);
+        }
+    }
+
+    @Override
+    public boolean isBlacklisted(String accessToken) {
+        return Boolean.TRUE.equals(stringRedisTemplate.hasKey(key(accessToken)));
+    }
+
+    private String key(String accessToken) {
+        return KEY_PREFIX + accessToken;
+    }
+}

--- a/src/main/java/com/shortkki/api/auth/infra/redis/RedisAccessTokenBlacklist.java
+++ b/src/main/java/com/shortkki/api/auth/infra/redis/RedisAccessTokenBlacklist.java
@@ -16,18 +16,18 @@ public class RedisAccessTokenBlacklist implements AccessTokenBlacklist {
     private final StringRedisTemplate stringRedisTemplate;
 
     @Override
-    public void add(String accessToken, Duration ttl) {
+    public void add(String jti, Duration ttl) {
         if (ttl.isPositive()) {
-            stringRedisTemplate.opsForValue().set(key(accessToken), BLACKLISTED, ttl);
+            stringRedisTemplate.opsForValue().set(key(jti), BLACKLISTED, ttl);
         }
     }
 
     @Override
-    public boolean isBlacklisted(String accessToken) {
-        return Boolean.TRUE.equals(stringRedisTemplate.hasKey(key(accessToken)));
+    public boolean isBlacklisted(String jti) {
+        return Boolean.TRUE.equals(stringRedisTemplate.hasKey(key(jti)));
     }
 
-    private String key(String accessToken) {
-        return KEY_PREFIX + accessToken;
+    private String key(String jti) {
+        return KEY_PREFIX + jti;
     }
 }

--- a/src/main/java/com/shortkki/api/auth/infra/redis/RedisRefreshTokenStore.java
+++ b/src/main/java/com/shortkki/api/auth/infra/redis/RedisRefreshTokenStore.java
@@ -1,9 +1,14 @@
 package com.shortkki.api.auth.infra.redis;
 
 import com.shortkki.api.auth.application.port.RefreshTokenStore;
+import com.shortkki.global.error.ErrorCode;
+import com.shortkki.global.error.exception.BusinessException;
 import java.time.Duration;
+import java.util.Collections;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -12,11 +17,36 @@ public class RedisRefreshTokenStore implements RefreshTokenStore {
 
     private static final String KEY_PREFIX = "rt:member:";
 
+    private static final DefaultRedisScript<Long> ROTATE_REDIS_SCRIPT;
+
+    static {
+        ROTATE_REDIS_SCRIPT = new DefaultRedisScript<>();
+        ROTATE_REDIS_SCRIPT.setLocation(new ClassPathResource("redis/rotate-refresh-token.lua"));
+        ROTATE_REDIS_SCRIPT.setResultType(Long.class);
+    }
+
     private final StringRedisTemplate stringRedisTemplate;
 
     @Override
     public void store(Long memberId, String refreshToken, Duration ttl) {
         stringRedisTemplate.opsForValue().set(key(memberId), refreshToken, ttl);
+    }
+
+    @Override
+    public boolean rotate(Long memberId, String expectedToken, String newToken, Duration ttl) {
+        Long result = stringRedisTemplate.execute(
+                ROTATE_REDIS_SCRIPT,
+                Collections.singletonList(key(memberId)),
+                expectedToken,
+                newToken,
+                String.valueOf(ttl.getSeconds())
+        );
+
+        if (result == null || result == -1L) {
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+        }
+
+        return result == 1L;
     }
 
     @Override

--- a/src/main/java/com/shortkki/api/auth/infra/redis/RedisRefreshTokenStore.java
+++ b/src/main/java/com/shortkki/api/auth/infra/redis/RedisRefreshTokenStore.java
@@ -1,0 +1,35 @@
+package com.shortkki.api.auth.infra.redis;
+
+import com.shortkki.api.auth.application.port.RefreshTokenStore;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisRefreshTokenStore implements RefreshTokenStore {
+
+    private static final String KEY_PREFIX = "rt:member:";
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Override
+    public void store(Long memberId, String refreshToken, Duration ttl) {
+        stringRedisTemplate.opsForValue().set(key(memberId), refreshToken, ttl);
+    }
+
+    @Override
+    public String find(Long memberId) {
+        return stringRedisTemplate.opsForValue().get(key(memberId));
+    }
+
+    @Override
+    public void delete(Long memberId) {
+        stringRedisTemplate.delete(key(memberId));
+    }
+
+    private String key(Long memberId) {
+        return KEY_PREFIX + memberId;
+    }
+}

--- a/src/main/java/com/shortkki/api/member/controller/MemberController.java
+++ b/src/main/java/com/shortkki/api/member/controller/MemberController.java
@@ -57,7 +57,7 @@ public class MemberController {
     public ResponseEntity<BaseResponse<Void>> withdraw(
             @AuthenticationPrincipal LoginMember loginMember
     ) {
-        memberService.withdraw(loginMember.getId(), loginMember.getJti());
+        memberService.withdraw(loginMember.getId(), loginMember.getJti(), loginMember.getExp());
         return ResponseEntity.ok(BaseResponse.success());
     }
 }

--- a/src/main/java/com/shortkki/api/member/controller/MemberController.java
+++ b/src/main/java/com/shortkki/api/member/controller/MemberController.java
@@ -17,7 +17,6 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -56,11 +55,9 @@ public class MemberController {
     @Operation(summary = "회원 탈퇴")
     @DeleteMapping
     public ResponseEntity<BaseResponse<Void>> withdraw(
-            @AuthenticationPrincipal LoginMember loginMember,
-            @RequestHeader("Authorization") String authorization
+            @AuthenticationPrincipal LoginMember loginMember
     ) {
-        String accessToken = authorization.substring("Bearer ".length());
-        memberService.withdraw(loginMember.getId(), accessToken);
+        memberService.withdraw(loginMember.getId(), loginMember.getJti());
         return ResponseEntity.ok(BaseResponse.success());
     }
 }

--- a/src/main/java/com/shortkki/api/member/controller/MemberController.java
+++ b/src/main/java/com/shortkki/api/member/controller/MemberController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -55,9 +56,11 @@ public class MemberController {
     @Operation(summary = "회원 탈퇴")
     @DeleteMapping
     public ResponseEntity<BaseResponse<Void>> withdraw(
-            @AuthenticationPrincipal LoginMember loginMember
+            @AuthenticationPrincipal LoginMember loginMember,
+            @RequestHeader("Authorization") String authorization
     ) {
-        memberService.withdraw(loginMember.getId());
+        String accessToken = authorization.substring("Bearer ".length());
+        memberService.withdraw(loginMember.getId(), accessToken);
         return ResponseEntity.ok(BaseResponse.success());
     }
 }

--- a/src/main/java/com/shortkki/api/member/service/MemberService.java
+++ b/src/main/java/com/shortkki/api/member/service/MemberService.java
@@ -8,6 +8,7 @@ import com.shortkki.api.file.entity.FileMetadata;
 import com.shortkki.api.member.entity.Member;
 import com.shortkki.global.error.ErrorCode;
 import com.shortkki.global.error.exception.BadRequestException;
+import java.time.Duration;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -55,11 +56,14 @@ public class MemberService {
         validateNotDeleted(member);
         member.delete();
 
+        String jti = jwtTokenProvider.getJti(accessToken);
+        Duration ttl = jwtTokenProvider.getRemainingValidity(accessToken);
+
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
                 refreshTokenStore.delete(memberId);
-                accessTokenBlacklist.add(accessToken, jwtTokenProvider.getRemainingValidity(accessToken));
+                accessTokenBlacklist.add(jti, ttl);
             }
         });
     }

--- a/src/main/java/com/shortkki/api/member/service/MemberService.java
+++ b/src/main/java/com/shortkki/api/member/service/MemberService.java
@@ -3,7 +3,6 @@ package com.shortkki.api.member.service;
 import com.shortkki.api.auth.application.port.AccessTokenBlacklist;
 import com.shortkki.api.auth.application.port.RefreshTokenStore;
 import com.shortkki.api.file.application.service.FileMetadataQueryService;
-import com.shortkki.global.auth.jwt.JwtTokenProvider;
 import com.shortkki.api.file.entity.FileMetadata;
 import com.shortkki.api.member.entity.Member;
 import com.shortkki.global.error.ErrorCode;
@@ -11,6 +10,7 @@ import com.shortkki.global.error.exception.BadRequestException;
 import java.time.Duration;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -25,7 +25,9 @@ public class MemberService {
     private final FileMetadataQueryService fileMetadataQueryService;
     private final RefreshTokenStore refreshTokenStore;
     private final AccessTokenBlacklist accessTokenBlacklist;
-    private final JwtTokenProvider jwtTokenProvider;
+
+    @Value("${jwt.access-token-validity}")
+    private long accessTokenValidityMs;
 
     public void updateProfile(Long memberId, String name, Long profileImgFileId) {
         Member member = memberQueryService.findMember(memberId);
@@ -51,19 +53,15 @@ public class MemberService {
         }
     }
 
-    public void withdraw(Long memberId, String accessToken) {
+    public void withdraw(Long memberId, String jti) {
         Member member = memberQueryService.findMember(memberId);
         validateNotDeleted(member);
         member.delete();
-
-        String jti = jwtTokenProvider.getJti(accessToken);
-        Duration ttl = jwtTokenProvider.getRemainingValidity(accessToken);
-
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
                 refreshTokenStore.delete(memberId);
-                accessTokenBlacklist.add(jti, ttl);
+                accessTokenBlacklist.add(jti, Duration.ofMillis(accessTokenValidityMs));
             }
         });
     }

--- a/src/main/java/com/shortkki/api/member/service/MemberService.java
+++ b/src/main/java/com/shortkki/api/member/service/MemberService.java
@@ -1,6 +1,9 @@
 package com.shortkki.api.member.service;
 
+import com.shortkki.api.auth.application.port.AccessTokenBlacklist;
+import com.shortkki.api.auth.application.port.RefreshTokenStore;
 import com.shortkki.api.file.application.service.FileMetadataQueryService;
+import com.shortkki.global.auth.jwt.JwtTokenProvider;
 import com.shortkki.api.file.entity.FileMetadata;
 import com.shortkki.api.member.entity.Member;
 import com.shortkki.global.error.ErrorCode;
@@ -9,6 +12,8 @@ import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +22,9 @@ public class MemberService {
 
     private final MemberQueryService memberQueryService;
     private final FileMetadataQueryService fileMetadataQueryService;
+    private final RefreshTokenStore refreshTokenStore;
+    private final AccessTokenBlacklist accessTokenBlacklist;
+    private final JwtTokenProvider jwtTokenProvider;
 
     public void updateProfile(Long memberId, String name, Long profileImgFileId) {
         Member member = memberQueryService.findMember(memberId);
@@ -42,10 +50,18 @@ public class MemberService {
         }
     }
 
-    public void withdraw(Long memberId) {
+    public void withdraw(Long memberId, String accessToken) {
         Member member = memberQueryService.findMember(memberId);
         validateNotDeleted(member);
         member.delete();
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                refreshTokenStore.delete(memberId);
+                accessTokenBlacklist.add(accessToken, jwtTokenProvider.getRemainingValidity(accessToken));
+            }
+        });
     }
 
     private void validateNotDeleted(Member member) {

--- a/src/main/java/com/shortkki/api/member/service/MemberService.java
+++ b/src/main/java/com/shortkki/api/member/service/MemberService.java
@@ -8,9 +8,9 @@ import com.shortkki.api.member.entity.Member;
 import com.shortkki.global.error.ErrorCode;
 import com.shortkki.global.error.exception.BadRequestException;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -25,9 +25,6 @@ public class MemberService {
     private final FileMetadataQueryService fileMetadataQueryService;
     private final RefreshTokenStore refreshTokenStore;
     private final AccessTokenBlacklist accessTokenBlacklist;
-
-    @Value("${jwt.access-token-validity}")
-    private long accessTokenValidityMs;
 
     public void updateProfile(Long memberId, String name, Long profileImgFileId) {
         Member member = memberQueryService.findMember(memberId);
@@ -53,15 +50,20 @@ public class MemberService {
         }
     }
 
-    public void withdraw(Long memberId, String jti) {
+    public void withdraw(Long memberId, String jti, Instant exp) {
         Member member = memberQueryService.findMember(memberId);
         validateNotDeleted(member);
         member.delete();
+        Duration remainingValidity = Duration.between(Instant.now(), exp);
+        if (remainingValidity.isNegative()) {
+            remainingValidity = Duration.ZERO;
+        }
+        final Duration ttl = remainingValidity;
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
                 refreshTokenStore.delete(memberId);
-                accessTokenBlacklist.add(jti, Duration.ofMillis(accessTokenValidityMs));
+                accessTokenBlacklist.add(jti, ttl);
             }
         });
     }

--- a/src/main/java/com/shortkki/global/auth/dto/LoginMember.java
+++ b/src/main/java/com/shortkki/global/auth/dto/LoginMember.java
@@ -18,13 +18,15 @@ public class LoginMember implements UserDetails {
     private final String email;
     private final String name;
     private final Role role;
+    private final String jti;
 
     @Builder
-    private LoginMember(Long id, String email, String name, Role role) {
+    private LoginMember(Long id, String email, String name, Role role, String jti) {
         this.id = id;
         this.email = email;
         this.name = name;
         this.role = role;
+        this.jti = jti;
     }
 
     public static LoginMember from(Member member) {

--- a/src/main/java/com/shortkki/global/auth/dto/LoginMember.java
+++ b/src/main/java/com/shortkki/global/auth/dto/LoginMember.java
@@ -8,6 +8,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 
@@ -19,15 +20,19 @@ public class LoginMember implements UserDetails {
     private final String name;
     private final Role role;
     private final String jti;
+    private final Instant exp;
 
     @Builder
-    private LoginMember(Long id, String email, String name, Role role, String jti) {
+    private LoginMember(Long id, String email, String name, Role role, String jti, Instant exp) {
         this.id = id;
         this.email = email;
         this.name = name;
         this.role = role;
         this.jti = jti;
+        this.exp = exp;
     }
+
+
 
     public static LoginMember from(Member member, String jti) {
         return LoginMember.builder()

--- a/src/main/java/com/shortkki/global/auth/dto/LoginMember.java
+++ b/src/main/java/com/shortkki/global/auth/dto/LoginMember.java
@@ -29,12 +29,13 @@ public class LoginMember implements UserDetails {
         this.jti = jti;
     }
 
-    public static LoginMember from(Member member) {
+    public static LoginMember from(Member member, String jti) {
         return LoginMember.builder()
                 .id(member.getId())
                 .email(member.getEmail())
                 .name(member.getName())
                 .role(member.getRole())
+                .jti(jti)
                 .build();
     }
 

--- a/src/main/java/com/shortkki/global/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/shortkki/global/auth/filter/JwtAuthenticationFilter.java
@@ -42,9 +42,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(token)) {
             try {
                 if (jwtTokenProvider.validateToken(token)) {
-                    String jti = jwtTokenProvider.getJti(token);
-                    if (jti != null && accessTokenBlacklist.isBlacklisted(jti)) {
+                    if (!jwtTokenProvider.isAccessToken(token)) {
                         throw new BusinessException(ErrorCode.INVALID_TOKEN);
+                    }
+                    try {
+                        String jti = jwtTokenProvider.getJti(token);
+                        if (jti == null) {
+                            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+                        }
+                        if (accessTokenBlacklist.isBlacklisted(jti)) {
+                            throw new BusinessException(ErrorCode.INVALID_TOKEN);
+                        }
+                    } catch (BusinessException e) {
+                        throw e;
+                    } catch (Exception e) {
+                        log.warn("블랙리스트 조회 실패, 건너뜀: {}", e.getMessage());
                     }
                     Authentication authentication = jwtTokenProvider.getAuthentication(token);
                     SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/com/shortkki/global/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/shortkki/global/auth/filter/JwtAuthenticationFilter.java
@@ -1,6 +1,8 @@
 package com.shortkki.global.auth.filter;
 
+import com.shortkki.api.auth.application.port.AccessTokenBlacklist;
 import com.shortkki.global.auth.jwt.JwtTokenProvider;
+import com.shortkki.global.error.ErrorCode;
 import com.shortkki.global.error.exception.BusinessException;
 import com.shortkki.global.response.BaseResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,6 +30,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final String BEARER_PREFIX = "Bearer ";
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final AccessTokenBlacklist accessTokenBlacklist;
     private final ObjectMapper objectMapper;
 
     @Override
@@ -39,9 +42,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(token)) {
             try {
                 if (jwtTokenProvider.validateToken(token)) {
+                    if (accessTokenBlacklist.isBlacklisted(token)) {
+                        throw new BusinessException(ErrorCode.INVALID_TOKEN);
+                    }
                     Authentication authentication = jwtTokenProvider.getAuthentication(token);
                     SecurityContextHolder.getContext().setAuthentication(authentication);
-                    // TODO: 멤버 존재 검증
                     log.debug(
                             "Set Authentication to SecurityContext for '{}', uri: {}",
                             authentication.getName(), request.getRequestURI()

--- a/src/main/java/com/shortkki/global/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/shortkki/global/auth/filter/JwtAuthenticationFilter.java
@@ -42,7 +42,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (StringUtils.hasText(token)) {
             try {
                 if (jwtTokenProvider.validateToken(token)) {
-                    if (accessTokenBlacklist.isBlacklisted(token)) {
+                    String jti = jwtTokenProvider.getJti(token);
+                    if (jti != null && accessTokenBlacklist.isBlacklisted(jti)) {
                         throw new BusinessException(ErrorCode.INVALID_TOKEN);
                     }
                     Authentication authentication = jwtTokenProvider.getAuthentication(token);

--- a/src/main/java/com/shortkki/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/shortkki/global/auth/jwt/JwtTokenProvider.java
@@ -58,6 +58,23 @@ public class JwtTokenProvider {
                 .compact();
     }
 
+    /** 테스트 전용 — 이미 만료된 AT 생성 */
+    public String createExpiredAccessToken(Long memberId, String email, Role role) {
+        Date now = new Date();
+        Date expired = new Date(now.getTime() - 1000); // 1초 전 만료
+
+        return Jwts.builder()
+                .id(UUID.randomUUID().toString())
+                .subject(String.valueOf(memberId))
+                .claim("email", email)
+                .claim("role", role.name())
+                .claim("type", "access")
+                .issuedAt(new Date(now.getTime() - 2000))
+                .expiration(expired)
+                .signWith(key)
+                .compact();
+    }
+
     public String createRefreshToken(Long memberId) {
         Date now = new Date();
         Date validity = new Date(now.getTime() + refreshTokenValidity);

--- a/src/main/java/com/shortkki/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/shortkki/global/auth/jwt/JwtTokenProvider.java
@@ -83,6 +83,7 @@ public class JwtTokenProvider {
                 .id(memberId)
                 .email(email)
                 .role(role)
+                .jti(claims.getId())
                 .build();
 
         return new UsernamePasswordAuthenticationToken(loginMember, "",

--- a/src/main/java/com/shortkki/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/shortkki/global/auth/jwt/JwtTokenProvider.java
@@ -101,6 +101,7 @@ public class JwtTokenProvider {
                 .email(email)
                 .role(role)
                 .jti(claims.getId())
+                .exp(claims.getExpiration().toInstant())
                 .build();
 
         return new UsernamePasswordAuthenticationToken(loginMember, "",

--- a/src/main/java/com/shortkki/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/shortkki/global/auth/jwt/JwtTokenProvider.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Date;
 
 @Slf4j
@@ -142,5 +143,11 @@ public class JwtTokenProvider {
         Claims claims = parseClaims(token);
         String type = claims.get("type", String.class);
         return "access".equals(type);
+    }
+
+    public Duration getRemainingValidity(String token) {
+        Claims claims = parseClaims(token);
+        long remainingMs = claims.getExpiration().getTime() - System.currentTimeMillis();
+        return remainingMs > 0 ? Duration.ofMillis(remainingMs) : Duration.ZERO;
     }
 }

--- a/src/main/java/com/shortkki/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/shortkki/global/auth/jwt/JwtTokenProvider.java
@@ -20,6 +20,7 @@ import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Date;
+import java.util.UUID;
 
 @Slf4j
 @Component
@@ -46,6 +47,7 @@ public class JwtTokenProvider {
         Date validity = new Date(now.getTime() + accessTokenValidity);
 
         return Jwts.builder()
+                .id(UUID.randomUUID().toString())
                 .subject(String.valueOf(memberId))
                 .claim("email", email)
                 .claim("role", role.name())
@@ -61,6 +63,7 @@ public class JwtTokenProvider {
         Date validity = new Date(now.getTime() + refreshTokenValidity);
 
         return Jwts.builder()
+                .id(UUID.randomUUID().toString())
                 .subject(String.valueOf(memberId))
                 .claim("type", "refresh")
                 .issuedAt(now)
@@ -143,6 +146,11 @@ public class JwtTokenProvider {
         Claims claims = parseClaims(token);
         String type = claims.get("type", String.class);
         return "access".equals(type);
+    }
+
+    public String getJti(String token) {
+        Claims claims = parseClaims(token);
+        return claims.getId();
     }
 
     public Duration getRemainingValidity(String token) {

--- a/src/main/java/com/shortkki/global/config/RedisConfig.java
+++ b/src/main/java/com/shortkki/global/config/RedisConfig.java
@@ -1,0 +1,15 @@
+package com.shortkki.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        return new StringRedisTemplate(connectionFactory);
+    }
+}

--- a/src/main/java/com/shortkki/global/error/ErrorCode.java
+++ b/src/main/java/com/shortkki/global/error/ErrorCode.java
@@ -26,6 +26,8 @@ public enum ErrorCode {
     PLATFORM_REQUIRED_FOR_GOOGLE(HttpStatus.BAD_REQUEST, "AUTH_005", "Google 로그인 시 platform은 필수입니다."),
     INVALID_ID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_006", "유효하지 않은 idToken입니다."),
     ID_TOKEN_OR_CODE_REQUIRED(HttpStatus.BAD_REQUEST, "AUTH_007", "idToken 또는 code 중 하나는 필수입니다."),
+    REFRESH_TOKEN_REUSED(HttpStatus.UNAUTHORIZED, "AUTH_008", "토큰이 탈취된 것으로 감지되어 강제 로그아웃되었습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "AUTH_009", "리프레시 토큰이 만료되었거나 존재하지 않습니다."),
 
     // Member
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER_001", "회원을 찾을 수 없습니다."),

--- a/src/main/java/com/shortkki/support/dev/service/DevService.java
+++ b/src/main/java/com/shortkki/support/dev/service/DevService.java
@@ -1,5 +1,6 @@
 package com.shortkki.support.dev.service;
 
+import com.shortkki.api.auth.application.port.RefreshTokenStore;
 import com.shortkki.api.auth.dto.LoginResponse;
 import com.shortkki.api.file.controller.dto.FileUploadRequest;
 import com.shortkki.api.file.controller.dto.FileUploadResponse;
@@ -9,9 +10,13 @@ import com.shortkki.api.file.application.service.FileMetadataService;
 import com.shortkki.api.member.entity.Member;
 import com.shortkki.api.member.service.MemberQueryService;
 import com.shortkki.global.auth.jwt.JwtTokenProvider;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Service
 @Transactional
@@ -21,12 +26,23 @@ public class DevService {
     private final MemberQueryService memberQueryService;
     private final FileMetadataService fileMetadataService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenStore refreshTokenStore;
+
+    @Value("${jwt.refresh-token-validity}")
+    private long refreshTokenValidityMs;
 
     public LoginResponse getLoginResponse(Long memberId) {
         Member member = memberQueryService.findMember(memberId);
 
         String accessToken = jwtTokenProvider.createAccessToken(memberId, member.getEmail(), member.getRole());
         String refreshToken = jwtTokenProvider.createRefreshToken(memberId);
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                refreshTokenStore.store(memberId, refreshToken, Duration.ofMillis(refreshTokenValidityMs));
+            }
+        });
 
         return LoginResponse.builder()
                 .accessToken(accessToken)

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -15,6 +15,11 @@ spring:
       ddl-auto: validate
     open-in-view: false
 
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT:6379}
+
   elasticsearch:
     uris: ${ELASTICSEARCH_URIS}
 

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -20,6 +20,11 @@ spring:
 #        show_sql: true
 #        format_sql: true
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
   elasticsearch:
     uris: http://localhost:9200
 

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -15,6 +15,11 @@ spring:
       ddl-auto: validate
     open-in-view: false
 
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT:6379}
+
   elasticsearch:
     uris: ${ELASTICSEARCH_URIS}
 

--- a/src/main/resources/redis/rotate-refresh-token.lua
+++ b/src/main/resources/redis/rotate-refresh-token.lua
@@ -1,0 +1,22 @@
+-- 원자적 Refresh Token 로테이션 (compare-and-swap)
+--
+-- KEYS[1] = rt:member:{memberId}
+-- ARGV[1] = expectedToken (현재 저장된 RT)
+-- ARGV[2] = newToken (교체할 새 RT)
+-- ARGV[3] = ttl (초 단위)
+--
+-- 반환: 1 = 교체 성공, 0 = 불일치(탈취 감지), -1 = 키 없음
+
+local stored = redis.call('GET', KEYS[1])
+
+if stored == false then
+    return -1
+end
+
+if stored == ARGV[1] then
+    redis.call('SET', KEYS[1], ARGV[2], 'EX', ARGV[3])
+    return 1
+end
+
+redis.call('DEL', KEYS[1])
+return 0

--- a/src/test/java/com/shortkki/test/auth/RefreshTokenRotationTest.java
+++ b/src/test/java/com/shortkki/test/auth/RefreshTokenRotationTest.java
@@ -150,7 +150,7 @@ class RefreshTokenRotationTest extends IntegrationTestBase {
         mockMvc.perform(post("/api/v1/auth/logout")
                         .header("Authorization", "Bearer " + at))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.message").value("로그아웃 성공"));
+                .andExpect(jsonPath("$.code").value("SUCCESS"));
 
         // then
         assertThat(refreshTokenStore.find(testMember.getId())).isNull();

--- a/src/test/java/com/shortkki/test/auth/RefreshTokenRotationTest.java
+++ b/src/test/java/com/shortkki/test/auth/RefreshTokenRotationTest.java
@@ -1,17 +1,16 @@
 package com.shortkki.test.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.shortkki.api.auth.application.port.AccessTokenBlacklist;
 import com.shortkki.api.auth.application.port.RefreshTokenStore;
-import com.shortkki.api.auth.dto.LogoutRequest;
 import com.shortkki.api.auth.dto.RefreshTokenRequest;
 import com.shortkki.api.member.entity.Member;
 import com.shortkki.api.member.entity.OAuthProvider;
-import com.shortkki.api.member.entity.Role;
 import com.shortkki.api.member.repository.MemberRepository;
 import com.shortkki.global.auth.jwt.JwtTokenProvider;
 import com.shortkki.test.support.IntegrationTestBase;
@@ -21,7 +20,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.MvcResult;
 
 class RefreshTokenRotationTest extends IntegrationTestBase {
 
@@ -45,96 +43,117 @@ class RefreshTokenRotationTest extends IntegrationTestBase {
                 .orElseGet(() -> memberRepository.save(
                         Member.create("rtr-test@test.com", "RTR테스터", "oauth-id-rtr", OAuthProvider.GOOGLE, null)
                 ));
+        // 테스트 간 격리
+        refreshTokenStore.delete(testMember.getId());
     }
 
-    @DisplayName("정상 리프레시 → 새 AT+RT 발급, 이전 RT 무효화")
-    @Test
-    void refresh_rotates_token() throws Exception {
-        // given
-        String oldRt = jwtTokenProvider.createRefreshToken(testMember.getId());
-        refreshTokenStore.store(testMember.getId(), oldRt, Duration.ofMinutes(10));
-
-        String expiredAt = jwtTokenProvider.createAccessToken(
-                testMember.getId(), testMember.getEmail(), testMember.getRole());
-        // AT가 만료되어야 리프레시 가능 → 짧은 유효기간으로 만료 시뮬레이션이 어려우므로
-        // 테스트에서는 AT 만료 검증을 건너뛰고 서비스 레이어를 직접 테스트
-
-        RefreshTokenRequest request = new RefreshTokenRequest(expiredAt, oldRt);
-
-        // when - AT가 아직 유효하면 400 반환 (AT 만료 전에는 리프레시 불가)
-        mockMvc.perform(post("/api/auth/refresh")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest());
-
-        // Redis에 RT가 여전히 존재하는지 확인
-        assertThat(refreshTokenStore.find(testMember.getId())).isEqualTo(oldRt);
-    }
-
-    @DisplayName("이전 RT 재사용 → AUTH_008 (탈취 감지) + Redis 키 삭제")
+    @DisplayName("이전 RT 재사용 → AUTH_008 (탈취 감지) + 전체 세션 강제 종료")
     @Test
     void reused_token_triggers_theft_detection() throws Exception {
-        // given: Redis에 newRt가 저장되어 있지만, oldRt로 리프레시 시도
+        // given: oldRt는 이미 교체된 이전 RT, newRt가 현재 유효한 RT
         String oldRt = jwtTokenProvider.createRefreshToken(testMember.getId());
         String newRt = jwtTokenProvider.createRefreshToken(testMember.getId());
         refreshTokenStore.store(testMember.getId(), newRt, Duration.ofMinutes(10));
 
-        // Redis 저장된 RT와 불일치하는 경우를 검증
-        assertThat(refreshTokenStore.find(testMember.getId())).isEqualTo(newRt);
-        assertThat(refreshTokenStore.find(testMember.getId())).isNotEqualTo(oldRt);
+        String expiredAt = jwtTokenProvider.createExpiredAccessToken(
+                testMember.getId(), testMember.getEmail(), testMember.getRole());
+
+        // when: 이전 RT로 refresh 시도
+        RefreshTokenRequest request = new RefreshTokenRequest(expiredAt, oldRt);
+        mockMvc.perform(post("/api/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_008"));
+
+        // then: 전체 세션 삭제 — newRt도 사용 불가
+        assertThat(refreshTokenStore.find(testMember.getId())).isNull();
     }
 
-    @DisplayName("로그아웃 → RT 삭제 + AT 블랙리스트 등록")
+    @DisplayName("로그아웃 후 AT 사용 → 블랙리스트 차단")
     @Test
-    void logout_deletes_refresh_token_and_blacklists_access_token() throws Exception {
+    void blacklisted_at_is_rejected_after_logout() throws Exception {
         // given
         String at = jwtTokenProvider.createAccessToken(
                 testMember.getId(), testMember.getEmail(), testMember.getRole());
         String rt = jwtTokenProvider.createRefreshToken(testMember.getId());
         refreshTokenStore.store(testMember.getId(), rt, Duration.ofMinutes(10));
 
-        LogoutRequest request = new LogoutRequest(rt);
+        // when: 로그아웃
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .header("Authorization", "Bearer " + at))
+                .andExpect(status().isOk());
+
+        // then: 로그아웃된 AT로 API 호출 → 차단
+        mockMvc.perform(get("/api/v1/members/profile")
+                        .header("Authorization", "Bearer " + at))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @DisplayName("로그아웃 후 refresh 시도 → AUTH_009 (RT 미존재)")
+    @Test
+    void refresh_after_logout_returns_auth_009() throws Exception {
+        // given
+        String at = jwtTokenProvider.createAccessToken(
+                testMember.getId(), testMember.getEmail(), testMember.getRole());
+        String rt = jwtTokenProvider.createRefreshToken(testMember.getId());
+        refreshTokenStore.store(testMember.getId(), rt, Duration.ofMinutes(10));
+
+        // 로그아웃
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .header("Authorization", "Bearer " + at))
+                .andExpect(status().isOk());
+
+        // when: 로그아웃 후 refresh 시도
+        String expiredAt = jwtTokenProvider.createExpiredAccessToken(
+                testMember.getId(), testMember.getEmail(), testMember.getRole());
+        RefreshTokenRequest request = new RefreshTokenRequest(expiredAt, rt);
+        mockMvc.perform(post("/api/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_009"));
+    }
+
+    @DisplayName("재로그인 시 기존 세션 무효화 → 이전 RT로 refresh 실패")
+    @Test
+    void new_login_invalidates_previous_session() throws Exception {
+        // given: 첫 번째 로그인
+        String oldRt = jwtTokenProvider.createRefreshToken(testMember.getId());
+        refreshTokenStore.store(testMember.getId(), oldRt, Duration.ofMinutes(10));
+
+        // when: 두 번째 로그인 (기존 RT 덮어씀)
+        String newRt = jwtTokenProvider.createRefreshToken(testMember.getId());
+        refreshTokenStore.store(testMember.getId(), newRt, Duration.ofMinutes(10));
+
+        // then: 이전 RT로 refresh 시도 → 탈취 감지
+        String expiredAt = jwtTokenProvider.createExpiredAccessToken(
+                testMember.getId(), testMember.getEmail(), testMember.getRole());
+        RefreshTokenRequest request = new RefreshTokenRequest(expiredAt, oldRt);
+        mockMvc.perform(post("/api/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value("AUTH_008"));
+    }
+
+    @DisplayName("로그아웃 → RT 삭제 + AT 블랙리스트 등록")
+    @Test
+    void logout_deletes_rt_and_blacklists_at() throws Exception {
+        // given
+        String at = jwtTokenProvider.createAccessToken(
+                testMember.getId(), testMember.getEmail(), testMember.getRole());
+        String rt = jwtTokenProvider.createRefreshToken(testMember.getId());
+        refreshTokenStore.store(testMember.getId(), rt, Duration.ofMinutes(10));
 
         // when
         mockMvc.perform(post("/api/v1/auth/logout")
-                        .header("Authorization", "Bearer " + at)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+                        .header("Authorization", "Bearer " + at))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("로그아웃 성공"));
 
         // then
         assertThat(refreshTokenStore.find(testMember.getId())).isNull();
-        String jti = jwtTokenProvider.getJti(at);
-        assertThat(accessTokenBlacklist.isBlacklisted(jti)).isTrue();
-    }
-
-    @DisplayName("재로그인 시 기존 세션 무효화 (새 RT 저장)")
-    @Test
-    void new_login_invalidates_previous_session() {
-        // given
-        String oldRt = jwtTokenProvider.createRefreshToken(testMember.getId());
-        refreshTokenStore.store(testMember.getId(), oldRt, Duration.ofMinutes(10));
-
-        // when: 새로운 RT 저장 (로그인 시뮬레이션)
-        String newRt = jwtTokenProvider.createRefreshToken(testMember.getId());
-        refreshTokenStore.store(testMember.getId(), newRt, Duration.ofMinutes(10));
-
-        // then: 이전 RT는 무효화됨
-        String storedRt = refreshTokenStore.find(testMember.getId());
-        assertThat(storedRt).isEqualTo(newRt);
-        assertThat(storedRt).isNotEqualTo(oldRt);
-    }
-
-    @DisplayName("로그아웃 후 리프레시 시도 → Redis에 RT 없음")
-    @Test
-    void refresh_after_logout_fails() throws Exception {
-        // given
-        String rt = jwtTokenProvider.createRefreshToken(testMember.getId());
-        refreshTokenStore.store(testMember.getId(), rt, Duration.ofMinutes(10));
-        refreshTokenStore.delete(testMember.getId());
-
-        // then
-        assertThat(refreshTokenStore.find(testMember.getId())).isNull();
+        assertThat(accessTokenBlacklist.isBlacklisted(jwtTokenProvider.getJti(at))).isTrue();
     }
 }

--- a/src/test/java/com/shortkki/test/auth/RefreshTokenRotationTest.java
+++ b/src/test/java/com/shortkki/test/auth/RefreshTokenRotationTest.java
@@ -93,10 +93,11 @@ class RefreshTokenRotationTest extends IntegrationTestBase {
         String rt = jwtTokenProvider.createRefreshToken(testMember.getId());
         refreshTokenStore.store(testMember.getId(), rt, Duration.ofMinutes(10));
 
-        LogoutRequest request = new LogoutRequest(at, rt);
+        LogoutRequest request = new LogoutRequest(rt);
 
         // when
-        mockMvc.perform(post("/api/auth/logout")
+        mockMvc.perform(post("/api/v1/auth/logout")
+                        .header("Authorization", "Bearer " + at)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())

--- a/src/test/java/com/shortkki/test/auth/RefreshTokenRotationTest.java
+++ b/src/test/java/com/shortkki/test/auth/RefreshTokenRotationTest.java
@@ -79,10 +79,7 @@ class RefreshTokenRotationTest extends IntegrationTestBase {
         String newRt = jwtTokenProvider.createRefreshToken(testMember.getId());
         refreshTokenStore.store(testMember.getId(), newRt, Duration.ofMinutes(10));
 
-        // AT는 만료된 것처럼 만들기 어려우므로, 서비스 직접 호출로 테스트할 수도 있지만
-        // 여기서는 Redis 저장된 RT와 불일치하는 경우를 검증
-
-        // Redis에 저장된 RT가 newRt인지 확인
+        // Redis 저장된 RT와 불일치하는 경우를 검증
         assertThat(refreshTokenStore.find(testMember.getId())).isEqualTo(newRt);
         assertThat(refreshTokenStore.find(testMember.getId())).isNotEqualTo(oldRt);
     }
@@ -107,7 +104,8 @@ class RefreshTokenRotationTest extends IntegrationTestBase {
 
         // then
         assertThat(refreshTokenStore.find(testMember.getId())).isNull();
-        assertThat(accessTokenBlacklist.isBlacklisted(at)).isTrue();
+        String jti = jwtTokenProvider.getJti(at);
+        assertThat(accessTokenBlacklist.isBlacklisted(jti)).isTrue();
     }
 
     @DisplayName("재로그인 시 기존 세션 무효화 (새 RT 저장)")

--- a/src/test/java/com/shortkki/test/auth/RefreshTokenRotationTest.java
+++ b/src/test/java/com/shortkki/test/auth/RefreshTokenRotationTest.java
@@ -1,0 +1,141 @@
+package com.shortkki.test.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.shortkki.api.auth.application.port.AccessTokenBlacklist;
+import com.shortkki.api.auth.application.port.RefreshTokenStore;
+import com.shortkki.api.auth.dto.LogoutRequest;
+import com.shortkki.api.auth.dto.RefreshTokenRequest;
+import com.shortkki.api.member.entity.Member;
+import com.shortkki.api.member.entity.OAuthProvider;
+import com.shortkki.api.member.entity.Role;
+import com.shortkki.api.member.repository.MemberRepository;
+import com.shortkki.global.auth.jwt.JwtTokenProvider;
+import com.shortkki.test.support.IntegrationTestBase;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
+
+class RefreshTokenRotationTest extends IntegrationTestBase {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private RefreshTokenStore refreshTokenStore;
+
+    @Autowired
+    private AccessTokenBlacklist accessTokenBlacklist;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member testMember;
+
+    @BeforeEach
+    void setUp() {
+        testMember = memberRepository.findByEmail("rtr-test@test.com")
+                .orElseGet(() -> memberRepository.save(
+                        Member.create("rtr-test@test.com", "RTR테스터", "oauth-id-rtr", OAuthProvider.GOOGLE, null)
+                ));
+    }
+
+    @DisplayName("정상 리프레시 → 새 AT+RT 발급, 이전 RT 무효화")
+    @Test
+    void refresh_rotates_token() throws Exception {
+        // given
+        String oldRt = jwtTokenProvider.createRefreshToken(testMember.getId());
+        refreshTokenStore.store(testMember.getId(), oldRt, Duration.ofMinutes(10));
+
+        String expiredAt = jwtTokenProvider.createAccessToken(
+                testMember.getId(), testMember.getEmail(), testMember.getRole());
+        // AT가 만료되어야 리프레시 가능 → 짧은 유효기간으로 만료 시뮬레이션이 어려우므로
+        // 테스트에서는 AT 만료 검증을 건너뛰고 서비스 레이어를 직접 테스트
+
+        RefreshTokenRequest request = new RefreshTokenRequest(expiredAt, oldRt);
+
+        // when - AT가 아직 유효하면 400 반환 (AT 만료 전에는 리프레시 불가)
+        mockMvc.perform(post("/api/auth/refresh")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+
+        // Redis에 RT가 여전히 존재하는지 확인
+        assertThat(refreshTokenStore.find(testMember.getId())).isEqualTo(oldRt);
+    }
+
+    @DisplayName("이전 RT 재사용 → AUTH_008 (탈취 감지) + Redis 키 삭제")
+    @Test
+    void reused_token_triggers_theft_detection() throws Exception {
+        // given: Redis에 newRt가 저장되어 있지만, oldRt로 리프레시 시도
+        String oldRt = jwtTokenProvider.createRefreshToken(testMember.getId());
+        String newRt = jwtTokenProvider.createRefreshToken(testMember.getId());
+        refreshTokenStore.store(testMember.getId(), newRt, Duration.ofMinutes(10));
+
+        // AT는 만료된 것처럼 만들기 어려우므로, 서비스 직접 호출로 테스트할 수도 있지만
+        // 여기서는 Redis 저장된 RT와 불일치하는 경우를 검증
+
+        // Redis에 저장된 RT가 newRt인지 확인
+        assertThat(refreshTokenStore.find(testMember.getId())).isEqualTo(newRt);
+        assertThat(refreshTokenStore.find(testMember.getId())).isNotEqualTo(oldRt);
+    }
+
+    @DisplayName("로그아웃 → RT 삭제 + AT 블랙리스트 등록")
+    @Test
+    void logout_deletes_refresh_token_and_blacklists_access_token() throws Exception {
+        // given
+        String at = jwtTokenProvider.createAccessToken(
+                testMember.getId(), testMember.getEmail(), testMember.getRole());
+        String rt = jwtTokenProvider.createRefreshToken(testMember.getId());
+        refreshTokenStore.store(testMember.getId(), rt, Duration.ofMinutes(10));
+
+        LogoutRequest request = new LogoutRequest(at, rt);
+
+        // when
+        mockMvc.perform(post("/api/auth/logout")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("로그아웃 성공"));
+
+        // then
+        assertThat(refreshTokenStore.find(testMember.getId())).isNull();
+        assertThat(accessTokenBlacklist.isBlacklisted(at)).isTrue();
+    }
+
+    @DisplayName("재로그인 시 기존 세션 무효화 (새 RT 저장)")
+    @Test
+    void new_login_invalidates_previous_session() {
+        // given
+        String oldRt = jwtTokenProvider.createRefreshToken(testMember.getId());
+        refreshTokenStore.store(testMember.getId(), oldRt, Duration.ofMinutes(10));
+
+        // when: 새로운 RT 저장 (로그인 시뮬레이션)
+        String newRt = jwtTokenProvider.createRefreshToken(testMember.getId());
+        refreshTokenStore.store(testMember.getId(), newRt, Duration.ofMinutes(10));
+
+        // then: 이전 RT는 무효화됨
+        String storedRt = refreshTokenStore.find(testMember.getId());
+        assertThat(storedRt).isEqualTo(newRt);
+        assertThat(storedRt).isNotEqualTo(oldRt);
+    }
+
+    @DisplayName("로그아웃 후 리프레시 시도 → Redis에 RT 없음")
+    @Test
+    void refresh_after_logout_fails() throws Exception {
+        // given
+        String rt = jwtTokenProvider.createRefreshToken(testMember.getId());
+        refreshTokenStore.store(testMember.getId(), rt, Duration.ofMinutes(10));
+        refreshTokenStore.delete(testMember.getId());
+
+        // then
+        assertThat(refreshTokenStore.find(testMember.getId())).isNull();
+    }
+}

--- a/src/test/java/com/shortkki/test/security/WithMockMemberSecurityContextFactory.java
+++ b/src/test/java/com/shortkki/test/security/WithMockMemberSecurityContextFactory.java
@@ -1,6 +1,8 @@
 package com.shortkki.test.security;
 
 import com.shortkki.global.auth.dto.LoginMember;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
@@ -20,6 +22,7 @@ public final class WithMockMemberSecurityContextFactory
                 .name(annotation.name())
                 .role(annotation.role())
                 .jti(UUID.randomUUID().toString())
+                .exp(Instant.now().plus(1, ChronoUnit.HOURS))
                 .build();
 
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(

--- a/src/test/java/com/shortkki/test/security/WithMockMemberSecurityContextFactory.java
+++ b/src/test/java/com/shortkki/test/security/WithMockMemberSecurityContextFactory.java
@@ -1,6 +1,7 @@
 package com.shortkki.test.security;
 
 import com.shortkki.global.auth.dto.LoginMember;
+import java.util.UUID;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -18,6 +19,7 @@ public final class WithMockMemberSecurityContextFactory
                 .email(annotation.email())
                 .name(annotation.name())
                 .role(annotation.role())
+                .jti(UUID.randomUUID().toString())
                 .build();
 
         UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(

--- a/src/test/java/com/shortkki/test/support/IntegrationTestBase.java
+++ b/src/test/java/com/shortkki/test/support/IntegrationTestBase.java
@@ -8,7 +8,10 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
@@ -25,9 +28,19 @@ public abstract class IntegrationTestBase {
             new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:8.12.2")
                     .withEnv("xpack.security.enabled", "false");
 
+    static final GenericContainer<?> REDIS = new GenericContainer<>("redis:7-alpine")
+            .withExposedPorts(6379);
+
     static {
         MYSQL.start();
         ELASTICSEARCH.start();
+        REDIS.start();
+    }
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", REDIS::getHost);
+        registry.add("spring.data.redis.port", () -> REDIS.getMappedPort(6379));
     }
 
     @Autowired


### PR DESCRIPTION
## 🔥 변경 사항
 - Redis 인프라 추가 (의존성, docker-compose, 환경별 yaml 설정)
  - RefreshTokenStore / AccessTokenBlacklist Port-Adapter 패턴 구현
  - 로그인 시 RT를 Redis에 저장 (단일 세션 정책)
  - refreshAccessToken에 RTR 로직 추가 (재사용 탐지 AUTH_008, 미존재 AUTH_009)
  - 로그아웃 엔드포인트 추가 (RT 삭제 + AT 블랙리스트)
  - JwtAuthenticationFilter에 AT 블랙리스트 검사 추가
  - 회원 탈퇴 시 RT 삭제 + AT 블랙리스트 처리
  - DB-Redis 원자성 보장 (TransactionSynchronization.afterCommit)
  - Testcontainers Redis 추가 + RTR 통합 테스트

<br>

## 🧩 관련 이슈
- related to #90 
- closes #90 

<br>

## 🛠 작업 내용
- [ ] 주요 작업 1
- [ ] 주요 작업 2

<br>

## 📸 스크린샷 / 결과 (선택)
*UI 변경, API 응답 결과 등 첨부*

(내용)

<br>

## ⚠️ 참고 사항 (선택)
- 리뷰 참고 사항
- 중점 확인 사항
- 배포 영향 여부

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 로그아웃 엔드포인트 추가 - 사용자가 명시적으로 로그아웃 가능
  * 액세스 토큰 블랙리스트 기능 - 로그아웃 후 토큰 무효화
  * 리프레시 토큰 로테이션 - 토큰 탈취 감지 및 자동 세션 종료

* **보안 개선**
  * 토큰 재사용 감지 기능 추가로 계정 도용 방지
  * 세션 관리 강화

* **인프라**
  * Redis 지원 추가로 토큰 관리 기능 확대
<!-- end of auto-generated comment: release notes by coderabbit.ai -->